### PR TITLE
recovery samples. some api additions to get samples working

### DIFF
--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -295,7 +295,11 @@ public final class MemberAsync {
      * @return a completable
      */
     public Completable verifyAlias(String verificationId, String code) {
-        return client.verifyAlias(verificationId, code);
+        Completable done = client.verifyAlias(verificationId, code);
+        done.blockingAwait();
+        // We probably have at least one new alias; refresh alias cache.
+        this.aliases = new ArrayList<>(client.getAliases().blockingSingle());
+        return done;
     }
 
     /**

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -297,11 +297,7 @@ public final class MemberAsync {
      * @return a completable
      */
     public Completable verifyAlias(String verificationId, String code) {
-        Completable done = client.verifyAlias(verificationId, code);
-        done.blockingAwait();
-        // We probably have at least one new alias; refresh alias cache.
-        this.aliases = new ArrayList<>(client.getAliases().blockingSingle());
-        return done;
+        return client.verifyAlias(verificationId, code);
     }
 
     /**

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -31,8 +31,8 @@ import io.reactivex.functions.Function;
 import io.token.gradle.TokenVersion;
 import io.token.proto.banklink.Banklink.BankAuthorization;
 import io.token.proto.common.alias.AliasProtos.Alias;
-import io.token.proto.common.member.MemberProtos;
 import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation;
+import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation.Authorization;
 import io.token.proto.common.notification.NotificationProtos.NotifyStatus;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.proto.common.token.TokenProtos.TokenPayload;
@@ -265,6 +265,16 @@ public final class TokenIO implements Closeable {
      */
     public String beginRecovery(Alias alias) {
         return async.beginRecovery(alias).blockingSingle();
+    }
+
+    /**
+     * Create a recovery authorization for some agent to sign.
+     * @param memberId Id of member we claim to be.
+     * @param privilegedKey new privileged key we want to use.
+     * @return authorization structure for agent to sign
+     */
+    public Authorization createRecoveryAuthorization(String memberId, Key privilegedKey) {
+        return async.createRecoveryAuthorization(memberId, privilegedKey).blockingSingle();
     }
 
     /**

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -43,6 +43,7 @@ import io.token.proto.common.member.MemberProtos;
 import io.token.proto.common.member.MemberProtos.MemberOperation;
 import io.token.proto.common.member.MemberProtos.MemberOperationMetadata;
 import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation;
+import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation.Authorization;
 import io.token.proto.common.notification.NotificationProtos.NotifyStatus;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.proto.common.token.TokenProtos.TokenPayload;
@@ -302,6 +303,19 @@ public final class TokenIOAsync implements Closeable {
     public Observable<String> beginRecovery(Alias alias) {
         UnauthenticatedClient unauthenticated = ClientFactory.unauthenticated(channel);
         return unauthenticated.beginRecovery(alias);
+    }
+
+    /**
+     * Create a recovery authorization for some agent to sign.
+     * @param memberId Id of member we claim to be.
+     * @param privilegedKey new privileged key we want to use.
+     * @return authorization structure for agent to sign
+     */
+    public Observable<Authorization> createRecoveryAuthorization(
+            String memberId,
+            Key privilegedKey) {
+        UnauthenticatedClient unauthenticated = ClientFactory.unauthenticated(channel);
+        return unauthenticated.createRecoveryAuthorization(memberId, privilegedKey);
     }
 
     /**

--- a/samples/src/main/java/io/token/sample/MemberRecoverySample.java
+++ b/samples/src/main/java/io/token/sample/MemberRecoverySample.java
@@ -1,0 +1,140 @@
+package io.token.sample;
+
+import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+
+import io.token.Member;
+import io.token.TokenIO;
+import io.token.proto.common.alias.AliasProtos.Alias;
+import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation;
+import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation.Authorization;
+import io.token.proto.common.member.MemberProtos.RecoveryRule;
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.proto.common.security.SecurityProtos.Signature;
+import io.token.security.CryptoEngine;
+import io.token.security.InMemoryKeyStore;
+import io.token.security.TokenCryptoEngine;
+
+import java.util.Arrays;
+
+public class MemberRecoverySample {
+    public Member agentMember; /* used by complex recovery rule sample */
+
+    public void setUpDefaultRecoveryRule(Member member) {
+        member.useDefaultRecoveryRule();
+    }
+
+    /**
+     * Recover previously-created member, assuming they were
+     * configured with a "normal consumer" recovery rule.
+     *
+     * @param tokenIO SDK client
+     * @param alias alias of member to recoverWithDefaultRule
+     * @return recovered member
+     */
+    public Member recoverWithDefaultRule(TokenIO tokenIO, Alias alias) {
+        String verificationId = tokenIO.beginRecovery(alias);
+
+        String memberId = tokenIO.getMemberId(alias);
+
+        // In the real world, we'd prompt the user to enter the code emailed to them.
+        // Since our test member uses an auto-verify email address, any string will work,
+        // so we use "1thru6".
+        Member recoveredMember = tokenIO.completeRecoveryWithDefaultRule(
+                memberId,
+                verificationId,
+                "1thru6");
+        // We can use the same verification code to re-claim this alias.
+        recoveredMember.verifyAlias(verificationId, "1thru6");
+
+        return recoveredMember;
+    }
+
+    private void tellRecoveryAgentMemberId(String memberId) {} /* this simple sample uses a no op */
+
+    /**
+     * Illustrate setting up a recovery rule more complex than "normal consumer"
+     * mode, without the "normal consumer" shortcuts.
+     * @param newMember newly-created member we are setting up
+     * @param tokenIO SDK client
+     * @param agentAlias Alias of recovery agent.
+     */
+    public void setUpComplexRecoveryRule(
+            Member newMember,
+            TokenIO tokenIO,
+            Alias agentAlias) {
+        // Someday in the future, this user might ask the recovery agent
+        // "Please tell Token that I am the member with ID m:12345678 ."
+        // While we're setting up this new member, we need to tell the
+        // recovery agent the new member ID so the agent can "remember" later.
+        tellRecoveryAgentMemberId(newMember.memberId());
+
+        String agentId = tokenIO.getMemberId(agentAlias);
+        RecoveryRule recoveryRule = RecoveryRule.newBuilder()
+                .setPrimaryAgent(agentId)
+                .build();
+        newMember.addRecoveryRule(recoveryRule);
+    }
+
+    /* this simple sample approves everybody */
+    private boolean checkMemberId(String memberId) {
+        return true;
+    }
+
+    /**
+     * Illustrate how a recovery agent signs an authorization.
+     * @param authorization client's claim to be some member
+     * @return if authorization seems legitimate, return signature; else error
+     */
+    public Signature getRecoveryAgentSignature(Authorization authorization) {
+        // "Remember" whether this person who claims to be member with
+        // the ID m:12345678 really is:
+        boolean isCorrect = checkMemberId(authorization.getMemberId());
+        if (isCorrect) {
+            return agentMember.authorizeRecovery(authorization);
+        }
+        throw new RuntimeException("I don't authorize this");
+    }
+
+    /**
+     * Illustrate recovery using a not-normal-"consumer mode" recovery agent.
+     * @param tokenIO SDK client
+     * @param alias Alias of member to recover
+     * @return recovered member
+     */
+    public Member recoverWithComplexRule(
+            TokenIO tokenIO,
+            Alias alias) {
+        // complexRecovery begin snippet to include in docs
+        String memberId = tokenIO.getMemberId(alias);
+
+        CryptoEngine cryptoEngine = new TokenCryptoEngine(memberId, new InMemoryKeyStore());
+        Key newKey = cryptoEngine.generateKey(PRIVILEGED);
+
+        String verificationId = tokenIO.beginRecovery(alias);
+        Authorization authorization = tokenIO.createRecoveryAuthorization(memberId, newKey);
+
+        // ask recovery agent to verify that I really am this member
+        Signature agentSignature = getRecoveryAgentSignature(authorization);
+
+        // We have all the signed authorizations we need.
+        // (In this example, "all" is just one.)
+        MemberRecoveryOperation mro = MemberRecoveryOperation.newBuilder()
+                .setAuthorization(authorization)
+                .setAgentSignature(agentSignature)
+                .build();
+        Member recoveredMember = tokenIO.completeRecovery(
+                memberId,
+                Arrays.asList(mro),
+                newKey,
+                cryptoEngine);
+        // after recovery, aliases aren't verified
+
+        // In the real world, we'd prompt the user to enter the code emailed to them.
+        // Since our test member uses an auto-verify email address, any string will work,
+        // so we use "1thru6".
+        recoveredMember.verifyAlias(verificationId, "1thru6");
+        // complexRecovery end snippet to include in docs
+
+        return recoveredMember;
+    }
+}

--- a/samples/src/main/java/io/token/sample/MemberRecoverySample.java
+++ b/samples/src/main/java/io/token/sample/MemberRecoverySample.java
@@ -74,6 +74,10 @@ public class MemberRecoverySample {
         String agentId = tokenIO.getMemberId(agentAlias);
         RecoveryRule recoveryRule = RecoveryRule.newBuilder()
                 .setPrimaryAgent(agentId)
+                // This example doesn't call .setSecondaryAgents ,
+                // but could have. If it had, then recovery would have
+                // required one secondary agent authorization along with
+                // the primary agent authorization.
                 .build();
         newMember.addRecoveryRule(recoveryRule);
     }

--- a/samples/src/main/java/io/token/sample/MemberRecoverySample.java
+++ b/samples/src/main/java/io/token/sample/MemberRecoverySample.java
@@ -16,6 +16,9 @@ import io.token.security.TokenCryptoEngine;
 
 import java.util.Arrays;
 
+/**
+ * Illustrate steps of Member recovery.
+ */
 public class MemberRecoverySample {
     public Member agentMember; /* used by complex recovery rule sample */
 

--- a/samples/src/test/java/io/token/sample/MemberRecoverySampleTest.java
+++ b/samples/src/test/java/io/token/sample/MemberRecoverySampleTest.java
@@ -1,0 +1,63 @@
+package io.token.sample;
+
+import static io.token.sample.TestUtil.createClient;
+import static io.token.sample.TestUtil.randomAlias;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.token.Member;
+import io.token.TokenIO;
+import io.token.proto.common.alias.AliasProtos.Alias;
+
+import org.junit.Test;
+
+/**
+ * Created by larryhosken on 11/16/17.
+ */
+public class MemberRecoverySampleTest {
+
+    @Test
+    public void recoveryDefault() { // "normal consumer" recovery using "shortcuts"
+        try (TokenIO tokenIO = createClient()) {
+            MemberRecoverySample mrs = new MemberRecoverySample();
+
+            // set up
+            Alias originalAlias = randomAlias();
+            Member originalMember = tokenIO.createMember(originalAlias);
+            mrs.setUpDefaultRecoveryRule(originalMember);
+
+            TokenIO otherTokenIO = createClient();
+            Member recoveredMember = mrs.recoverWithDefaultRule(
+                    otherTokenIO,
+                    originalAlias);
+            Alias recoveredAlias = recoveredMember.firstAlias();
+            assertThat(recoveredAlias).isEqualTo(originalAlias);
+        }
+    }
+
+    @Test
+    public void recoveryComplex() {
+        try (TokenIO tokenIO = createClient()) {
+            MemberRecoverySample mrs = new MemberRecoverySample();
+
+            TokenIO agentTokenIO = createClient();
+            Alias agentAlias = randomAlias();
+            Member agentMember = agentTokenIO.createMember(agentAlias);
+
+            mrs.agentMember = agentMember;
+
+            // set up
+            Alias originalAlias = randomAlias();
+            Member originalMember = tokenIO.createMember(originalAlias);
+            mrs.setUpComplexRecoveryRule(originalMember, tokenIO, agentAlias);
+
+            // recover
+            TokenIO otherTokenIO = createClient();
+            Member recoveredMember = mrs.recoverWithComplexRule(
+                    otherTokenIO,
+                    originalAlias);
+            // make sure it worked
+            Alias recoveredAlias = recoveredMember.firstAlias();
+            assertThat(recoveredAlias).isEqualTo(originalAlias);
+        }
+    }
+}

--- a/samples/src/test/java/io/token/sample/MemberRecoverySampleTest.java
+++ b/samples/src/test/java/io/token/sample/MemberRecoverySampleTest.java
@@ -11,7 +11,7 @@ import io.token.proto.common.alias.AliasProtos.Alias;
 import org.junit.Test;
 
 /**
- * Created by larryhosken on 11/16/17.
+ * Tests for member-recovery sample code.
  */
 public class MemberRecoverySampleTest {
 


### PR DESCRIPTION
sample code showing: setting up recovery for default recovery; recovering via default; setting up non-default; recovering via non-default

tweaked sdk behavior for verifyAlias; update SDK's cache of aliases if verifyAlias is succeeding.

creating an authorization needs member's lastHash; added an API to fetch member info and put its lastHash into an authorization.