### PR TITLE
login name is confusing, so change it

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 If you're upgrading to a new version of the SDK,
 see this list for Java APIs that have changed:
 
-## Release 1.0.82
+## Release 1.0.84
 
 The `login` methods in TokenIO and TokenIOAsync were renamed to `getMember`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 If you're upgrading to a new version of the SDK,
 see this list for Java APIs that have changed:
 
+## Release 1.0.82
+
+The `login` methods in TokenIO and TokenIOAsync were renamed to `useMember`.
+
 ## Release 1.0.79
 
 MemberAsync.aliases() and MemberAsync.firstAlias() now return

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ see this list for Java APIs that have changed:
 
 ## Release 1.0.82
 
-The `login` methods in TokenIO and TokenIOAsync were renamed to `useMember`.
+The `login` methods in TokenIO and TokenIOAsync were renamed to `getMember`.
 
 ## Release 1.0.79
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.83'
+    version = '1.0.84'
 
     apply plugin: 'io.token.gradle.publish'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.82'
+    version = '1.0.83'
 
     apply plugin: 'io.token.gradle.publish'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.81'
+    version = '1.0.82'
 
     apply plugin: 'io.token.gradle.publish'
 }

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -186,8 +186,8 @@ public class TokenIO implements Closeable {
      * @param memberId member id
      * @return logged in member
      */
-    public Member login(String memberId) {
-        return async.login(memberId)
+    public Member useMember(String memberId) {
+        return async.useMember(memberId)
                 .map(new MemberFunction())
                 .blockingSingle();
     }

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -186,8 +186,8 @@ public class TokenIO implements Closeable {
      * @param memberId member id
      * @return member
      */
-    public Member useMember(String memberId) {
-        return async.useMember(memberId)
+    public Member getMember(String memberId) {
+        return async.getMember(memberId)
                 .map(new MemberFunction())
                 .blockingSingle();
     }

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -181,10 +181,10 @@ public class TokenIO implements Closeable {
     }
 
     /**
-     * Logs in an existing member to the system.
+     * Return a MemberAsync set up to use some Token member's keys (assuming we have them).
      *
      * @param memberId member id
-     * @return logged in member
+     * @return member
      */
     public Member useMember(String memberId) {
         return async.useMember(memberId)

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -193,6 +193,20 @@ public class TokenIO implements Closeable {
     }
 
     /**
+     * Return a MemberAsync set up to use some Token member's keys (assuming we have them).
+     *
+     * @deprecated login's name changed to getMember
+     * @param memberId member id
+     * @return member
+     */
+    @Deprecated
+    public Member login(String memberId) {
+        return async.getMember(memberId)
+                .map(new MemberFunction())
+                .blockingSingle();
+    }
+
+    /**
      * Notifies to link accounts.
      *
      * @param alias alias to notify

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -64,7 +64,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Create a new member using the {@link #createMember}  method or log in an
- * existing member using {@link #login}.
+ * existing member using {@link #useMember}.
  *
  * <p>The class provides async API with {@link TokenIO} providing a synchronous
  * version. {@link TokenIO} instance can be obtained by calling {@link #sync}
@@ -215,7 +215,7 @@ public class TokenIOAsync implements Closeable {
      * @param memberId member id
      * @return logged in member
      */
-    public Observable<MemberAsync> login(String memberId) {
+    public Observable<MemberAsync> useMember(String memberId) {
         CryptoEngine crypto = cryptoFactory.create(memberId);
         final Client client = ClientFactory.authenticated(channel, memberId, crypto);
         return client

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -227,6 +227,26 @@ public class TokenIOAsync implements Closeable {
     }
 
     /**
+     * Return a Member set up to use some Token member's keys (assuming we have them).
+     *
+     * @deprecated login's name changed to getMember
+     * @param memberId member id
+     * @return member
+     */
+    @Deprecated
+    public Observable<MemberAsync> login(String memberId) {
+        CryptoEngine crypto = cryptoFactory.create(memberId);
+        final Client client = ClientFactory.authenticated(channel, memberId, crypto);
+        return client
+                .getMember(memberId)
+                .map(new Function<MemberProtos.Member, MemberAsync>() {
+                    public MemberAsync apply(MemberProtos.Member member) {
+                        return new MemberAsync(member, client);
+                    }
+                });
+    }
+
+    /**
      * Notifies to link an account.
      *
      * @param alias alias to notify

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -214,7 +214,7 @@ public class TokenIOAsync implements Closeable {
      * @param memberId member id
      * @return member
      */
-    public Observable<MemberAsync> useMember(String memberId) {
+    public Observable<MemberAsync> getMember(String memberId) {
         CryptoEngine crypto = cryptoFactory.create(memberId);
         final Client client = ClientFactory.authenticated(channel, memberId, crypto);
         return client

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -63,8 +63,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Create a new member using the {@link #createMember}  method or log in an
- * existing member using {@link #useMember}.
+ * An SDK Client that interacts with TokenOS.
  *
  * <p>The class provides async API with {@link TokenIO} providing a synchronous
  * version. {@link TokenIO} instance can be obtained by calling {@link #sync}
@@ -210,10 +209,10 @@ public class TokenIOAsync implements Closeable {
     }
 
     /**
-     * Logs in an existing member to the system.
+     * Return a Member set up to use some Token member's keys (assuming we have them).
      *
      * @param memberId member id
-     * @return logged in member
+     * @return member
      */
     public Observable<MemberAsync> useMember(String memberId) {
         CryptoEngine crypto = cryptoFactory.create(memberId);

--- a/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
+++ b/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
@@ -73,7 +73,7 @@ import java.util.List;
 /**
  * Similar to {@link Client} but is only used for a handful of requests that
  * don't require authentication. We use this client to create new member or
- * login an existing one and switch to the authenticated {@link Client}.
+ * useMember an existing one and switch to the authenticated {@link Client}.
  */
 public final class UnauthenticatedClient {
     private final GatewayServiceFutureStub gateway;

--- a/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
+++ b/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
@@ -73,7 +73,7 @@ import java.util.List;
 /**
  * Similar to {@link Client} but is only used for a handful of requests that
  * don't require authentication. We use this client to create new member or
- * useMember an existing one and switch to the authenticated {@link Client}.
+ * getMember an existing one and switch to the authenticated {@link Client}.
  */
 public final class UnauthenticatedClient {
     private final GatewayServiceFutureStub gateway;

--- a/samples/src/main/java/io/token/sample/GetBalanceSample.java
+++ b/samples/src/main/java/io/token/sample/GetBalanceSample.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Two ways to get balances of a logged-in member's bank accounts.
+ * Two ways to get balances of a member's bank accounts.
  */
 public final class GetBalanceSample {
     /**

--- a/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
+++ b/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
@@ -36,7 +36,7 @@ public class ProvisionDeviceSample {
     public static Member useProvisionedDevice(TokenIO tokenIO, Alias alias) {
         String memberId = tokenIO.getMemberId(alias);
         // Uses the key that remote member approved (we hope)
-        Member member = tokenIO.useMember(memberId);
+        Member member = tokenIO.getMember(memberId);
         return member;
     }
 }

--- a/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
+++ b/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
@@ -31,12 +31,12 @@ public class ProvisionDeviceSample {
      * Log in on provisioned device (assuming "remote" member approved key).
      * @param tokenIO SDK client
      * @param alias member's alias
-     * @return Member , logged in
+     * @return Member
      */
     public static Member useProvisionedDevice(TokenIO tokenIO, Alias alias) {
         String memberId = tokenIO.getMemberId(alias);
         // Uses the key that remote member approved (we hope)
-        Member localLoggedIn = tokenIO.useMember(memberId);
-        return localLoggedIn;
+        Member member = tokenIO.useMember(memberId);
+        return member;
     }
 }

--- a/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
+++ b/samples/src/main/java/io/token/sample/ProvisionDeviceSample.java
@@ -36,7 +36,7 @@ public class ProvisionDeviceSample {
     public static Member useProvisionedDevice(TokenIO tokenIO, Alias alias) {
         String memberId = tokenIO.getMemberId(alias);
         // Uses the key that remote member approved (we hope)
-        Member localLoggedIn = tokenIO.login(memberId);
+        Member localLoggedIn = tokenIO.useMember(memberId);
         return localLoggedIn;
     }
 }


### PR DESCRIPTION
A developer had some reasonable questions about `TokenIO.login`, paraphrased: "...but there's no API to log out. What happens when a member is logged in? Is a session established? OK to login the same member several times?" Colin points out that we could change the "login" name to something less confusing.