### PR TITLE
Fingerprint hybrid

### DIFF
--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -53,7 +53,6 @@ import javax.security.auth.x500.X500Principal;
 public final class AKSCryptoEngine implements CryptoEngine {
     private static final String KEY_NAME = "tokenapp_key";
     private static final Key.Algorithm KEY_ALGORITHM = Key.Algorithm.ECDSA_SHA256;
-    private static final int AUTHENTICATION_DURATION_SECONDS = 5;
 
     private final String memberId;
     private final Context context;
@@ -104,7 +103,7 @@ public final class AKSCryptoEngine implements CryptoEngine {
                         .setDigests(KeyProperties.DIGEST_SHA256)
                         .setUserAuthenticationRequired(keyLevel != Key.Level.LOW)
                         .setUserAuthenticationValidityDurationSeconds(
-                            AUTHENTICATION_DURATION_SECONDS);
+                            userAuthenticationStore.authenticationTimeSeconds());
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     // On Android N and above, we can invalidate the key if the user changes
@@ -163,8 +162,7 @@ public final class AKSCryptoEngine implements CryptoEngine {
         return new AKSSigner(
                 getKeyFromKeyStore(keyLevel),
                 keyLevel,
-                userAuthenticationStore,
-                AUTHENTICATION_DURATION_SECONDS);
+                userAuthenticationStore);
     }
 
     /**

--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -27,7 +27,6 @@ import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import com.google.common.hash.Hashing;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.util.codec.ByteEncoding;

--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -60,7 +60,6 @@ public final class AKSCryptoEngine implements CryptoEngine {
     private final Context context;
     private final UserAuthenticationStore userAuthenticationStore;
     private final KeyStore keyStore;
-    private final FingerprintManagerCompat fingerprintManager;
 
     /**
      * Creates an instance.
@@ -80,7 +79,6 @@ public final class AKSCryptoEngine implements CryptoEngine {
         } catch (KeyStoreException ex) {
             throw new RuntimeException(ex);
         }
-        this.fingerprintManager = FingerprintManagerCompat.from(context);
     }
 
     /**
@@ -105,15 +103,10 @@ public final class AKSCryptoEngine implements CryptoEngine {
                         KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY)
                         .setAlgorithmParameterSpec(new ECGenParameterSpec("secp256r1"))
                         .setDigests(KeyProperties.DIGEST_SHA256)
-                        .setUserAuthenticationRequired(keyLevel != Key.Level.LOW);
-
-                if (!fingerprintManager.hasEnrolledFingerprints()) {
-                    // On devices without a fingerprint sensor, limit authentication validity
-                    // for a short amount of time, to force use to reauthenticate for every
-                    // privileged operation
-                    builder.setUserAuthenticationValidityDurationSeconds(
+                        .setUserAuthenticationRequired(keyLevel != Key.Level.LOW)
+                        .setUserAuthenticationValidityDurationSeconds(
                             AUTHENTICATION_DURATION_SECONDS);
-                }
+
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     // On Android N and above, we can invalidate the key if the user changes
                     // their biometrics
@@ -172,8 +165,7 @@ public final class AKSCryptoEngine implements CryptoEngine {
                 getKeyFromKeyStore(keyLevel),
                 keyLevel,
                 userAuthenticationStore,
-                AUTHENTICATION_DURATION_SECONDS,
-                fingerprintManager);
+                AUTHENTICATION_DURATION_SECONDS);
     }
 
     /**

--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -103,7 +103,7 @@ public final class AKSCryptoEngine implements CryptoEngine {
                         .setDigests(KeyProperties.DIGEST_SHA256)
                         .setUserAuthenticationRequired(keyLevel != Key.Level.LOW)
                         .setUserAuthenticationValidityDurationSeconds(
-                            userAuthenticationStore.authenticationTimeSeconds());
+                            userAuthenticationStore.authenticationDurationSeconds());
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     // On Android N and above, we can invalidate the key if the user changes

--- a/android/src/main/java/io/token/security/AKSSigner.java
+++ b/android/src/main/java/io/token/security/AKSSigner.java
@@ -3,7 +3,6 @@ package io.token.security;
 import android.os.Build;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.UserNotAuthenticatedException;
-import android.support.v4.hardware.fingerprint.FingerprintManagerCompat;
 import com.google.protobuf.Message;
 import io.token.proto.ProtoJson;
 import io.token.proto.common.security.SecurityProtos.Key;
@@ -68,14 +67,10 @@ public class AKSSigner implements Signer{
      */
     @Override
     public String sign(String payload) {
-        Signature cached = userAuthenticationStore.getSignature(payload);
-        System.out.println("Signing.....Signature is: " + cached);
-        Signature s = cached;
+        Signature s = null;
         try {
-            if (s == null) {
-                s = Signature.getInstance("SHA256withECDSA");
-                s.initSign(((PrivateKeyEntry) entry).getPrivateKey());
-            }
+            s = Signature.getInstance("SHA256withECDSA");
+            s.initSign(((PrivateKeyEntry) entry).getPrivateKey());
 
             // If we are in an old device ad this is a privileged signer / operation
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && keyLevel != Key.Level.LOW) {

--- a/android/src/main/java/io/token/security/AKSSigner.java
+++ b/android/src/main/java/io/token/security/AKSSigner.java
@@ -78,7 +78,7 @@ public class AKSSigner implements Signer{
                 // If user authentication has expired
                 if (System.currentTimeMillis() >= userAuthenticationStore.userAuthenticatedTime()
                                         + authenticationTimeSeconds * 1000) {
-                    throw new TokenAuthenticationException(s);
+                    throw new TokenAuthenticationException(null);
                 }
             }
 
@@ -96,7 +96,7 @@ public class AKSSigner implements Signer{
                     // only happens on new devices (Android M or later) which is why we do an additional
                     // check above, for the older devices. Before throwing, the signature is saved
                     // for later
-                    throw new TokenAuthenticationException(s);
+                    throw new TokenAuthenticationException(null);
                 } else if (ex instanceof KeyPermanentlyInvalidatedException) {
                     // Throws when the user has changed their device passcode or biometrics
                     throw new TokenInvalidKeyException(ex);

--- a/android/src/main/java/io/token/security/AKSSigner.java
+++ b/android/src/main/java/io/token/security/AKSSigner.java
@@ -24,17 +24,21 @@ public class AKSSigner implements Signer{
     private final Entry entry;
     private final Key.Level keyLevel;
     private final UserAuthenticationStore userAuthenticationStore;
-    private final int authenticationTimeSeconds;
 
+    /**
+     * Creates a KeyStore signer.
+     *
+     * @param entry entry in the Android KeyStore
+     * @param keyLevel level of the key in the entry
+     * @param userAuthenticationStore store for user authentication
+     */
     AKSSigner(
             Entry entry,
             Key.Level keyLevel,
-            UserAuthenticationStore userAuthenticationStore,
-            int authenticationTimeSeconds) {
+            UserAuthenticationStore userAuthenticationStore) {
         this.entry = entry;
         this.keyLevel = keyLevel;
         this.userAuthenticationStore = userAuthenticationStore;
-        this.authenticationTimeSeconds = authenticationTimeSeconds;
     }
 
     /**
@@ -73,13 +77,8 @@ public class AKSSigner implements Signer{
             s.initSign(((PrivateKeyEntry) entry).getPrivateKey());
 
             // If this is a privileged signer / operation
-            if (keyLevel != Key.Level.LOW) {
-
-                // If user authentication has expired
-                if (System.currentTimeMillis() >= userAuthenticationStore.userAuthenticatedTime()
-                                        + authenticationTimeSeconds * 1000) {
-                    throw new TokenAuthenticationException(null);
-                }
+            if (keyLevel != Key.Level.LOW && !userAuthenticationStore.isAuthenticated()) {
+                throw new TokenAuthenticationException(null);
             }
 
             s.update(payload.getBytes("UTF-8"));

--- a/android/src/main/java/io/token/security/AKSSigner.java
+++ b/android/src/main/java/io/token/security/AKSSigner.java
@@ -72,8 +72,8 @@ public class AKSSigner implements Signer{
             s = Signature.getInstance("SHA256withECDSA");
             s.initSign(((PrivateKeyEntry) entry).getPrivateKey());
 
-            // If we are in an old device ad this is a privileged signer / operation
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && keyLevel != Key.Level.LOW) {
+            // If this is a privileged signer / operation
+            if (keyLevel != Key.Level.LOW) {
 
                 // If user authentication has expired
                 if (System.currentTimeMillis() >= userAuthenticationStore.userAuthenticatedTime()

--- a/android/src/main/java/io/token/security/UserAuthenticationStore.java
+++ b/android/src/main/java/io/token/security/UserAuthenticationStore.java
@@ -1,12 +1,20 @@
 package io.token.security;
 
+import java.security.Signature;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Stores the last time the user authenticated. This is used for old phones, where we cannot
  * use the KeyStore to check for user authentication.
  */
 public class UserAuthenticationStore {
-    long userAuthenticatedTime = 0;
-    public UserAuthenticationStore() {}
+    private long userAuthenticatedTime = 0;
+    private final Map<String, Signature> signatureObjectCache;
+
+    public UserAuthenticationStore() {
+        signatureObjectCache = new HashMap<>();
+    }
 
     public void authenticateUser() {
         userAuthenticatedTime = System.currentTimeMillis();
@@ -18,5 +26,13 @@ public class UserAuthenticationStore {
 
     public long userAuthenticatedTime() {
         return userAuthenticatedTime;
+    }
+
+    public Signature getSignature(String payload) {
+        return signatureObjectCache.get(payload);
+    }
+
+    public void putSignature(String payload, Signature signature) {
+        signatureObjectCache.put(payload, signature);
     }
 }

--- a/android/src/main/java/io/token/security/UserAuthenticationStore.java
+++ b/android/src/main/java/io/token/security/UserAuthenticationStore.java
@@ -1,20 +1,13 @@
 package io.token.security;
 
-import java.security.Signature;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Stores the last time the user authenticated. This is used for old phones, where we cannot
  * use the KeyStore to check for user authentication.
  */
 public class UserAuthenticationStore {
     private long userAuthenticatedTime = 0;
-    private final Map<String, Signature> signatureObjectCache;
 
-    public UserAuthenticationStore() {
-        signatureObjectCache = new HashMap<>();
-    }
+    public UserAuthenticationStore() { }
 
     public void authenticateUser() {
         userAuthenticatedTime = System.currentTimeMillis();
@@ -26,13 +19,5 @@ public class UserAuthenticationStore {
 
     public long userAuthenticatedTime() {
         return userAuthenticatedTime;
-    }
-
-    public Signature getSignature(String payload) {
-        return signatureObjectCache.get(payload);
-    }
-
-    public void putSignature(String payload, Signature signature) {
-        signatureObjectCache.put(payload, signature);
     }
 }

--- a/android/src/main/java/io/token/security/UserAuthenticationStore.java
+++ b/android/src/main/java/io/token/security/UserAuthenticationStore.java
@@ -5,9 +5,22 @@ package io.token.security;
  * use the KeyStore to check for user authentication.
  */
 public class UserAuthenticationStore {
+    private static final int AUTHENTICATION_DURATION_SECONDS_DEFAULT = 5;
+    private final int authenticationDurationSeconds;
     private long userAuthenticatedTime = 0;
 
-    public UserAuthenticationStore() { }
+    /**
+     * Creates a store for authentication time of user
+     *
+     * @param authenticationDurationSeconds how many seconds the authentication lasts for
+     */
+    public UserAuthenticationStore(int authenticationDurationSeconds) {
+        this.authenticationDurationSeconds = authenticationDurationSeconds;
+    }
+
+    public UserAuthenticationStore() {
+        this.authenticationDurationSeconds = AUTHENTICATION_DURATION_SECONDS_DEFAULT;
+    }
 
     public void authenticateUser() {
         userAuthenticatedTime = System.currentTimeMillis();
@@ -17,7 +30,12 @@ public class UserAuthenticationStore {
         userAuthenticatedTime = 0;
     }
 
-    public long userAuthenticatedTime() {
-        return userAuthenticatedTime;
+    public boolean isAuthenticated() {
+        return (System.currentTimeMillis() <
+                userAuthenticatedTime + authenticationDurationSeconds * 1000);
+    }
+
+    public int authenticationTimeSeconds() {
+        return authenticationDurationSeconds;
     }
 }

--- a/android/src/main/java/io/token/security/UserAuthenticationStore.java
+++ b/android/src/main/java/io/token/security/UserAuthenticationStore.java
@@ -35,7 +35,7 @@ public class UserAuthenticationStore {
                 userAuthenticatedTime + authenticationDurationSeconds * 1000);
     }
 
-    public int authenticationTimeSeconds() {
+    public int authenticationDurationSeconds() {
         return authenticationDurationSeconds;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.91'
+    version = '1.0.92-SNAPSHOT'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.92-SNAPSHOT'
+    version = '1.0.92'
 }


### PR DESCRIPTION
Lowers authentication time, catches another exception for authentication, replaces Signature CryptoObject with null. This is because next time the app makes an API call, the payload will change, and thus the Signature will be different, so we unfortunately can't rely on the CryptoObject.

