### PR TITLE
Don't expire the authentication after every signature

### DIFF
--- a/android/src/main/java/io/token/security/AKSSigner.java
+++ b/android/src/main/java/io/token/security/AKSSigner.java
@@ -84,9 +84,6 @@ public class AKSSigner implements Signer{
             s.update(payload.getBytes("UTF-8"));
             byte[] signature = s.sign();
 
-            // Only allow one privileged signature for each authentication
-            userAuthenticationStore.expireUserAuthentication();
-
             return ByteEncoding.serialize(signature);
         } catch (GeneralSecurityException | UnsupportedEncodingException ex) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/android/src/main/java/io/token/security/UserAuthenticationStore.java
+++ b/android/src/main/java/io/token/security/UserAuthenticationStore.java
@@ -5,7 +5,7 @@ package io.token.security;
  * use the KeyStore to check for user authentication.
  */
 public class UserAuthenticationStore {
-    private static final int AUTHENTICATION_DURATION_SECONDS_DEFAULT = 5;
+    private static final int AUTHENTICATION_DURATION_SECONDS_DEFAULT = 7;
     private final int authenticationDurationSeconds;
     private long userAuthenticatedTime = 0;
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.92'
+    version = '1.0.93'
 }


### PR DESCRIPTION
Since approveKey has multiple signatures, we can't force authentication on each signature. This makes us rely on the timeout (increased to 7 seconds to allow time for round trips), or on the client, who can expire the authentication using the UserAuthenticationStore.