### PR TITLE
sample code += carefully use access token

### DIFF
--- a/samples/src/main/java/io/token/sample/RedeemAccessTokenSample.java
+++ b/samples/src/main/java/io/token/sample/RedeemAccessTokenSample.java
@@ -5,11 +5,16 @@ import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 import io.token.Account;
 import io.token.Member;
 import io.token.proto.common.money.MoneyProtos.Money;
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.proto.common.token.TokenProtos.AccessBody.Resource;
+import io.token.proto.common.token.TokenProtos.Token;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
- * Redeems an information access token.
+ * Redeems an information access token. Assumes token has "allAccounts" access when using it.
  */
 public final class RedeemAccessTokenSample {
     /**
@@ -17,7 +22,7 @@ public final class RedeemAccessTokenSample {
      *
      * @param grantee grantee Token member
      * @param tokenId ID of the access token to redeem
-     * @return list of grantor's accounts accessed by the grantee
+     * @return balance of one of grantor's acounts
      */
     public static Money redeemAccessToken(Member grantee, String tokenId) {
         // Access grantor's account list by applying
@@ -27,8 +32,55 @@ public final class RedeemAccessTokenSample {
 
         // Get the data we want
         Money balance0 = grantorAccounts.get(0).getCurrentBalance(STANDARD);
-
         // When done using access, clear token from grantee client.
+        grantee.clearAccessToken();
+        return balance0;
+    }
+
+    /**
+     * Redeems an information access token. Does not assume token has "allAccounts" access.
+     *
+     * @param grantee grantee Token member
+     * @param tokenId ID of the access token to redeem
+     * @return balance of one of grantor's accounts (or empty Money proto if no account found)
+     */
+    public static Money carefullyUseAccessToken(Member grantee, String tokenId) {
+        Token accessToken = grantee.getToken(tokenId);
+        while (!accessToken.getReplacedByTokenId().isEmpty()) {
+            accessToken = grantee.getToken(accessToken.getReplacedByTokenId());
+        }
+        Set<String> accountIds = new HashSet<>();
+        List<Resource> resources = accessToken.getPayload().getAccess().getResourcesList();
+        boolean haveAllBalancesAccess = false;
+        boolean haveAllAccountsAccess = false;
+        for (int i = 0; i < resources.size(); i++) {
+            Resource resource = resources.get(i);
+            switch (resource.getResourceCase()) {
+                case ALL_BALANCES:
+                    haveAllBalancesAccess = true;
+                    break;
+                case ALL_ACCOUNTS:
+                    haveAllAccountsAccess = true;
+                    break;
+                case BALANCE:
+                    accountIds.add(resource.getBalance().getAccountId());
+                    break;
+                default:
+                    break;
+            }
+        }
+        grantee.useAccessToken(accessToken.getId());
+        if (haveAllAccountsAccess && haveAllBalancesAccess) {
+            List<Account> grantorAccounts = grantee.getAccounts();
+            for (int i = 0; i < grantorAccounts.size(); i++) {
+                accountIds.add(grantorAccounts.get(i).id());
+            }
+        }
+        if (accountIds.size() < 1) {
+            return Money.getDefaultInstance();
+        }
+        String account0Id = accountIds.iterator().next();
+        Money balance0 = grantee.getAvailableBalance(account0Id, Key.Level.LOW);
         grantee.clearAccessToken();
         return balance0;
     }

--- a/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
+++ b/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
@@ -1,18 +1,25 @@
 package io.token.sample;
 
 import static io.token.sample.CreateAndEndorseAccessTokenSample.createAccessToken;
+import static io.token.sample.RedeemAccessTokenSample.carefullyUseAccessToken;
+
 import static io.token.sample.RedeemAccessTokenSample.redeemAccessToken;
 import static io.token.sample.TestUtil.createClient;
 import static io.token.sample.TestUtil.createMemberAndLinkAccounts;
 import static io.token.sample.TestUtil.randomAlias;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.token.AccessTokenBuilder;
+import io.token.Account;
 import io.token.Member;
 import io.token.TokenIO;
 import io.token.proto.MoneyUtil;
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.money.MoneyProtos.Money;
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.proto.common.token.TokenProtos;
 import io.token.proto.common.token.TokenProtos.Token;
+import io.token.proto.common.token.TokenProtos.TokenOperationResult;
 
 import java.math.BigDecimal;
 
@@ -27,9 +34,42 @@ public class RedeemAccessTokenSampleTest {
             Member grantee = tokenIO.createMember(granteeAlias);
 
             Token token = createAccessToken(grantor, granteeAlias);
-
             Money balance0 = redeemAccessToken(grantee, token.getId());
             assertThat(MoneyUtil.parseAmount(balance0.getValue())).isGreaterThan(BigDecimal.TEN);
+        }
+    }
+
+    @Test
+    public void useAccessTokenTest() {
+        try (TokenIO tokenIO = createClient()) {
+            Member grantor = tokenIO.createMember(randomAlias());
+            final String account1Id = LinkMemberAndBankSample.linkBankAccounts(grantor).get(0).id();
+            final String account2Id = LinkMemberAndBankSample.linkBankAccounts(grantor).get(0).id();
+            LinkMemberAndBankSample.linkBankAccounts(grantor).get(0); // a third account
+
+            Alias granteeAlias = randomAlias();
+            Member grantee = tokenIO.createMember(granteeAlias);
+
+            // get a token from doc sample code: all accounts, all balance
+            Token token1 = createAccessToken(grantor, granteeAlias);
+
+            Money balance1 = carefullyUseAccessToken(grantee, token1.getId());
+            assertThat(MoneyUtil.parseAmount(balance1.getValue())).isGreaterThan(BigDecimal.TEN);
+
+            TokenOperationResult replaceResult = grantor.replaceAndEndorseAccessToken(
+                    token1,
+                    AccessTokenBuilder.fromPayload(token1.getPayload())
+                            .forAccount(account1Id)
+                            .forAccount(account2Id)
+                            .forAccountBalances(account1Id)
+                            .forAccountBalances(account2Id));
+            final Token token3 = replaceResult.getToken();
+
+            Money balance3 = carefullyUseAccessToken(grantee, token1.getId()); // use replaced token
+            assertThat(MoneyUtil.parseAmount(balance3.getValue())).isGreaterThan(BigDecimal.TEN);
+
+            Money balance6 = carefullyUseAccessToken(grantee, token3.getId()); // use replaced token
+            assertThat(MoneyUtil.parseAmount(balance6.getValue())).isGreaterThan(BigDecimal.TEN);
         }
     }
 }


### PR DESCRIPTION
so far, our redeem-access-token sample code shows how to use a token that has allAccounts. But if the token-grantor replaces that allAccounts with something more specific, e.g., edits the permissions in our iPhone app, that sample code fails to fetch any data. This new sample code shows how to use allAccounts if granted else use more-specific permissions.