### PR TITLE
Pl 1049.payments

### DIFF
--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -765,7 +765,7 @@ public class MemberAsync {
 
     /**
      * Creates a new transfer token from a token payload. If external
-     * authorization is required, will throw exception.
+     * authorization is required, throws TransferTokenException.
      *
      * @param payload transfer token payload
      * @return transfer token returned by the server

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -764,7 +764,8 @@ public class MemberAsync {
     }
 
     /**
-     * Creates a new transfer token from a token payload.
+     * Creates a new transfer token from a token payload. If external
+     * authorization is required, will throw exception.
      *
      * @param payload transfer token payload
      * @return transfer token returned by the server
@@ -775,6 +776,7 @@ public class MemberAsync {
 
     /**
      * Creates a new transfer token from a token payload and browser factory.
+     * If external authorization is required, directs browser to authentication page.
      *
      * @param payload transfer token payload
      * @param browserFactory browser factory

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -774,6 +774,17 @@ public class MemberAsync {
     }
 
     /**
+     * Creates a new transfer token from a token payload and browser factory.
+     *
+     * @param payload transfer token payload
+     * @param browserFactory browser factory
+     * @return transfer token returned by the server
+     */
+    public Observable<Token> createTransferToken(TokenPayload payload, BrowserFactory browserFactory) {
+        return client.createTransferToken(payload, browserFactory);
+    }
+
+    /**
      * Creates an access token built from a given {@link AccessTokenBuilder}.
      *
      * @param accessTokenBuilder an {@link AccessTokenBuilder} to create access token from

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -780,7 +780,9 @@ public class MemberAsync {
      * @param browserFactory browser factory
      * @return transfer token returned by the server
      */
-    public Observable<Token> createTransferToken(TokenPayload payload, BrowserFactory browserFactory) {
+    public Observable<Token> createTransferToken(
+            TokenPayload payload,
+            BrowserFactory browserFactory) {
         return client.createTransferToken(payload, browserFactory);
     }
 

--- a/lib/src/main/java/io/token/TransferTokenBuilder.java
+++ b/lib/src/main/java/io/token/TransferTokenBuilder.java
@@ -135,9 +135,10 @@ public final class TransferTokenBuilder {
     }
 
     /**
-     * Sets the Browser Factory.
+     * Sets the browser factory used to request external authorization.
+     * Only needed for payments requiring external authorization.
      *
-     * @param browserFactory BrowserFactory
+     * @param browserFactory browser factory
      * @return builder
      */
     public TransferTokenBuilder setBrowserFactory(BrowserFactory browserFactory) {

--- a/lib/src/main/java/io/token/TransferTokenBuilder.java
+++ b/lib/src/main/java/io/token/TransferTokenBuilder.java
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
+import io.token.browser.BrowserFactory;
 import io.token.exceptions.TokenArgumentsException;
 import io.token.proto.banklink.Banklink.BankAuthorization;
 import io.token.proto.common.account.AccountProtos.BankAccount;
@@ -68,6 +69,8 @@ public final class TransferTokenBuilder {
 
     // Used for attaching files / data to tokens
     private final List<Payload> blobPayloads;
+
+    private BrowserFactory browserFactory;
 
     /**
      * Creates the builder object.
@@ -128,6 +131,17 @@ public final class TransferTokenBuilder {
                         .setTokenAuthorization(TokenAuthorization.newBuilder()
                                 .setAuthorization(bankAuthorization))
                         .build());
+        return this;
+    }
+
+    /**
+     * Sets the Browser Factory.
+     *
+     * @param browserFactory BrowserFactory
+     * @return builder
+     */
+    public TransferTokenBuilder setBrowserFactory(BrowserFactory browserFactory) {
+        this.browserFactory = browserFactory;
         return this;
     }
 
@@ -380,7 +394,10 @@ public final class TransferTokenBuilder {
                 .flatMapObservable(new Function<List<Attachment>, Observable<Token>>() {
                     public Observable<Token> apply(List<Attachment> attachments) {
                         payload.getTransferBuilder().addAllAttachments(attachments);
-                        return member.createTransferToken(payload.build());
+                        if (browserFactory == null) {
+                            return member.createTransferToken(payload.build());
+                        }
+                        return member.createTransferToken(payload.build(), browserFactory);
                     }
                 });
     }

--- a/lib/src/main/java/io/token/browser/BrowserClosedException.java
+++ b/lib/src/main/java/io/token/browser/BrowserClosedException.java
@@ -1,3 +1,25 @@
+/**
+ * Copyright (c) 2017 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package io.token.browser;
 
 /**

--- a/lib/src/main/java/io/token/rpc/Client.java
+++ b/lib/src/main/java/io/token/rpc/Client.java
@@ -551,7 +551,7 @@ public final class Client {
 
     /**
      * Creates a new transfer token from a token payload. If external
-     * authorization is required, will throw exception.
+     * authorization is required, throws TransferTokenException.
      *
      * @param payload transfer token payload
      * @return transfer token returned by the server

--- a/lib/src/main/java/io/token/rpc/Client.java
+++ b/lib/src/main/java/io/token/rpc/Client.java
@@ -550,7 +550,8 @@ public final class Client {
     }
 
     /**
-     * Creates a new transfer token. If external auth required, throws exception.
+     * Creates a new transfer token from a token payload. If external
+     * authorization is required, will throw exception.
      *
      * @param payload transfer token payload
      * @return transfer token returned by the server
@@ -572,7 +573,8 @@ public final class Client {
     }
 
     /**
-     * Create a new transfer token. If external auth required, directs browser to auth page.
+     * Creates a new transfer token from a token payload and browser factory.
+     * If external authorization is required, directs browser to authentication page.
      *
      * @param payload transfer token payload
      * @param browserFactory the browser factory

--- a/lib/src/main/java/io/token/rpc/Client.java
+++ b/lib/src/main/java/io/token/rpc/Client.java
@@ -31,7 +31,6 @@ import static io.token.proto.common.token.TokenProtos.TokenSignature.Action.ENDO
 import static io.token.proto.common.token.TokenProtos.TransferTokenStatus.FAILURE_EXTERNAL_AUTHORIZATION_REQUIRED;
 import static io.token.proto.common.token.TokenProtos.TransferTokenStatus.SUCCESS;
 import static io.token.rpc.util.Converters.toCompletable;
-import static io.token.util.Util.fetchUrl;
 import static io.token.util.Util.toObservable;
 
 import io.reactivex.Completable;
@@ -1515,11 +1514,7 @@ public final class Client {
                         .flatMap(new Function<URL, ObservableSource<String>>() {
                             @Override
                             public ObservableSource<String> apply(URL url) {
-                                try {
-                                    return fetchUrl(url);
-                                } catch (IOException e) {
-                                    return Observable.error(e);
-                                }
+                                return browser.fetchData(url);
                             }
                         })
                         .subscribe(


### PR DESCRIPTION
Implements createTransferToken with browser.

Example Use: Suppose the user wants to make a payment from a CMA9 account, using an instance of browser to authenticate.
1. User adds browserFactory to TransferTokenBuilder using .setBrowserFactory.
2. User calls executeAsync on the TransferTokenBuilder; this will initiate the payment and direct the browser to authenticate.
Note: The user does not need to call createTransferToken a second time after authorization is obtained--this call is made automagically.

Concrete code to test this functionality can be found on the 'testing' branch of android-lib-temp.