### PR TITLE
PL-1454

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.0.466',
+            tokenProto           : '1.0.467',
             tokenRpc             : '1.0.99',
             tokenSecurity        : '1.0.40',
             tokenUtil            : '1.0.16',
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.116'
+    version = '1.0.117'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.0.467',
+            tokenProto           : '1.0.468',
             tokenRpc             : '1.0.99',
             tokenSecurity        : '1.0.40',
             tokenUtil            : '1.0.16',

--- a/lib/src/main/java/io/token/Member.java
+++ b/lib/src/main/java/io/token/Member.java
@@ -30,6 +30,7 @@ import io.reactivex.functions.Function;
 import io.token.exceptions.BankAuthorizationRequiredException;
 import io.token.proto.PagedList;
 import io.token.proto.banklink.Banklink.BankAuthorization;
+import io.token.proto.banklink.Banklink.OauthBankAuthorization;
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.bank.BankProtos.BankInfo;
 import io.token.proto.common.blob.BlobProtos.Attachment;
@@ -987,13 +988,30 @@ public class Member {
     }
 
     /**
+     * Creates a test bank account in a fake bank and links the account.
+     *
+     * @param balance account balance to set
+     * @param currency currency code, e.g. "EUR"
+     * @return the linked account
+     */
+    public Account createAndLinkTestBankAccount(double balance, String currency) {
+        return async.createAndLinkTestBankAccount(balance, currency)
+                .map(new Function<AccountAsync, Account>() {
+                    @Override
+                    public Account apply(AccountAsync accountAsync) {
+                        return accountAsync.sync();
+                    }
+                }).blockingSingle();
+    }
+
+    /**
      * Creates a test bank account in a fake bank.
      *
      * @param balance account balance to set
-     * @param currency currency code, i.e. "EUR"
-     * @return bank authorization
+     * @param currency currency code, e.g. "EUR"
+     * @return OAuth bank authorization
      */
-    public BankAuthorization createTestBankAccount(double balance, String currency) {
+    public OauthBankAuthorization createTestBankAccount(double balance, String currency) {
         return async.createTestBankAccount(balance, currency).blockingSingle();
     }
 

--- a/samples/src/main/java/io/token/sample/LinkMemberAndBankSample.java
+++ b/samples/src/main/java/io/token/sample/LinkMemberAndBankSample.java
@@ -2,11 +2,6 @@ package io.token.sample;
 
 import io.token.Account;
 import io.token.Member;
-import io.token.proto.banklink.Banklink;
-import io.token.proto.banklink.Banklink.BankAuthorization;
-import io.token.proto.common.security.SecurityProtos.SealedMessage;
-
-import java.util.List;
 
 /**
  * Links a Token member and a bank.
@@ -23,10 +18,7 @@ public final class LinkMemberAndBankSample {
      * @param member Token member to link to a bank
      * @return linked token accounts
      */
-    public static List<Account> linkBankAccounts(Member member) {
-        BankAuthorization encryptedBankAuthorization =
-                member.createTestBankAccount(1000.0, "EUR");
-
-        return member.linkAccounts(encryptedBankAuthorization);
+    public static Account linkBankAccounts(Member member) {
+        return member.createAndLinkTestBankAccount(1000.0, "EUR");
     }
 }

--- a/samples/src/test/java/io/token/sample/GetBalanceSampleTest.java
+++ b/samples/src/test/java/io/token/sample/GetBalanceSampleTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.token.Member;
 import io.token.TokenIO;
-import io.token.proto.banklink.Banklink;
 import io.token.proto.common.money.MoneyProtos.Money;
 import io.token.proto.common.transaction.TransactionProtos.Balance;
 
@@ -20,9 +19,7 @@ public class GetBalanceSampleTest {
     public void memberGetBalanceSampleTest() {
         try (TokenIO tokenIO = createClient()) {
             Member member = tokenIO.createMember(randomAlias());
-            Banklink.BankAuthorization encryptedBankAuthorization =
-                    member.createTestBankAccount(1000.0, "EUR");
-            member.linkAccounts(encryptedBankAuthorization);
+            member.createAndLinkTestBankAccount(1000.0, "EUR");
 
             Map<String, Double> sums = GetBalanceSample.memberGetBalanceSample(member);
             assertThat(sums.get("EUR")).isEqualTo(1000.0);
@@ -33,9 +30,7 @@ public class GetBalanceSampleTest {
     public void accountGetBalanceSampleTest() {
         try (TokenIO tokenIO = createClient()) {
             Member member = tokenIO.createMember(randomAlias());
-            Banklink.BankAuthorization encryptedBankAuthorization =
-                    member.createTestBankAccount(1000.0, "EUR");
-            member.linkAccounts(encryptedBankAuthorization);
+            member.createAndLinkTestBankAccount(1000.0, "EUR");
 
             Map<String, Double> sums = GetBalanceSample.accountGetBalanceSample(member);
             assertThat(sums.get("EUR")).isEqualTo(1000.0);
@@ -46,14 +41,9 @@ public class GetBalanceSampleTest {
     public void memberGetBalancesSampleTest() {
         try (TokenIO tokenIO = createClient()) {
             Member member = tokenIO.createMember(randomAlias());
-            Banklink.BankAuthorization encryptedBankAuthorizationA =
-                    member.createTestBankAccount(1000.0, "EUR");
-            member.linkAccounts(encryptedBankAuthorizationA);
+            member.createAndLinkTestBankAccount(1000.0, "EUR");
 
-            Banklink.BankAuthorization encryptedBankAuthorizationB =
-                    member.createTestBankAccount(500.0, "EUR");
-
-            member.linkAccounts(encryptedBankAuthorizationB);
+            member.createAndLinkTestBankAccount(500.0, "EUR");
 
             List<Balance> balances = GetBalanceSample.memberGetBalanceListSample(member);
             assertThat(balances.size()).isEqualTo(2);

--- a/samples/src/test/java/io/token/sample/GetTransactionsSampleTest.java
+++ b/samples/src/test/java/io/token/sample/GetTransactionsSampleTest.java
@@ -31,13 +31,13 @@ public class GetTransactionsSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer transfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
 
             getTransactionsSample(payer);
@@ -54,13 +54,13 @@ public class GetTransactionsSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer transfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
 
             accountGetTransactionsSample(payer);

--- a/samples/src/test/java/io/token/sample/GetTransfersSampleTest.java
+++ b/samples/src/test/java/io/token/sample/GetTransfersSampleTest.java
@@ -29,13 +29,13 @@ public class GetTransfersSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer transfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
 
             getTransfersSample(payer);
@@ -49,13 +49,13 @@ public class GetTransfersSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer transfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
 
             getTransferTokensSample(payer);
@@ -69,13 +69,13 @@ public class GetTransfersSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer redeemedTransfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
 
             Transfer gotTransfer = getTransferSample(

--- a/samples/src/test/java/io/token/sample/PollNotificationsSampleTest.java
+++ b/samples/src/test/java/io/token/sample/PollNotificationsSampleTest.java
@@ -29,11 +29,11 @@ public class PollNotificationsSampleTest {
             Member payee = PollNotificationsSample.createMember(tokenIO);
 
             Alias payeeAlias = payee.firstAlias();
-            List<Account> accounts = LinkMemberAndBankSample.linkBankAccounts(payer);
+            Account account = LinkMemberAndBankSample.linkBankAccounts(payer);
             LinkMemberAndBankSample.linkBankAccounts(payee);
 
             TokenProtos.Token token = payer.createTransferToken(100.00, "EUR")
-                    .setAccountId(accounts.get(0).id())
+                    .setAccountId(account.id())
                     .setToAlias(payeeAlias)
                     .addDestination(Destinations.token(payee.memberId()))
                     .setRedeemerMemberId(payer.memberId())

--- a/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
+++ b/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
@@ -44,9 +44,9 @@ public class RedeemAccessTokenSampleTest {
     public void useAccessTokenTest() {
         try (TokenIO tokenIO = createClient()) {
             Member grantor = tokenIO.createMember(randomAlias());
-            final String account1Id = LinkMemberAndBankSample.linkBankAccounts(grantor).get(0).id();
-            final String account2Id = LinkMemberAndBankSample.linkBankAccounts(grantor).get(0).id();
-            LinkMemberAndBankSample.linkBankAccounts(grantor).get(0); // a third account
+            final String account1Id = LinkMemberAndBankSample.linkBankAccounts(grantor).id();
+            final String account2Id = LinkMemberAndBankSample.linkBankAccounts(grantor).id();
+            LinkMemberAndBankSample.linkBankAccounts(grantor); // a third account
 
             Alias granteeAlias = randomAlias();
             Member grantee = tokenIO.createMember(granteeAlias);

--- a/samples/src/test/java/io/token/sample/RedeemTransferTokenSampleTest.java
+++ b/samples/src/test/java/io/token/sample/RedeemTransferTokenSampleTest.java
@@ -26,13 +26,13 @@ public class RedeemTransferTokenSampleTest {
             Alias payeeAlias = randomAlias();
             Member payee = tokenIO.createMember(payeeAlias);
 
-            List<Account> payeeAccounts = LinkMemberAndBankSample.linkBankAccounts(payee);
+            Account payeeAccount = LinkMemberAndBankSample.linkBankAccounts(payee);
 
             Token token = createTransferToken(payer, payeeAlias);
 
             Transfer transfer = redeemTransferToken(
                     payee,
-                    payeeAccounts.get(0).id(),
+                    payeeAccount.id(),
                     token.getId());
             assertThat(transfer).isNotNull();
         }


### PR DESCRIPTION
Right now there is a "createTestBankAccount" sdk method that returns bank auth JSON. Since we are phasing out bank auth JSON, I want to add two methods and deprecate the old one:
- String generateTestBankAccount(balance, currency) // returns access token to link the account
- Account generateLinkedBankAccount(balance, currency) // actually links the account