### PR TITLE
Pl 1452

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.113'
+    version = '1.0.114'
 }

--- a/lib/src/main/java/io/token/Member.java
+++ b/lib/src/main/java/io/token/Member.java
@@ -383,7 +383,7 @@ public class Member {
      * @param bankId the bank id
      * @return list of linked accounts
      * @throws BankAuthorizationRequiredException if bank authorization payload
-     *                                              is required to link accounts
+     *     is required to link accounts
      */
     public List<Account> initiateAccountLinking(String bankId) {
         return async.initiateAccountLinking(bankId).blockingSingle();
@@ -406,7 +406,7 @@ public class Member {
      * @param accessToken OAuth access token
      * @return list of linked accounts
      * @throws BankAuthorizationRequiredException if bank authorization payload
-     *                                               is required to link accounts
+     *     is required to link accounts
      */
     public List<Account> linkAccounts(String bankId, String accessToken) {
         return toAccountList(async.linkAccounts(bankId, accessToken)).blockingSingle();

--- a/lib/src/main/java/io/token/Member.java
+++ b/lib/src/main/java/io/token/Member.java
@@ -385,8 +385,8 @@ public class Member {
      * @throws BankAuthorizationRequiredException if bank authorization payload
      *                                              is required to link accounts
      */
-    public List<Account> linkAccounts(String bankId) {
-        return async.linkAccounts(bankId).blockingSingle();
+    public List<Account> initiateAccountLinking(String bankId) {
+        return async.initiateAccountLinking(bankId).blockingSingle();
     }
 
     /**

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -524,7 +524,7 @@ public class MemberAsync {
      * @throws BankAuthorizationRequiredException if bank authorization payload
      *                                              is required to link accounts
      */
-    public Observable<List<Account>> linkAccounts(final String bankId)
+    public Observable<List<Account>> initiateAccountLinking(final String bankId)
             throws BankAuthorizationRequiredException {
         final String callbackUrl = String.format(
                 "https://%s/auth/callback",

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -522,7 +522,7 @@ public class MemberAsync {
      * @param bankId the bank id
      * @return observable list of linked accounts
      * @throws BankAuthorizationRequiredException if bank authorization payload
-     *                                              is required to link accounts
+     *     is required to link accounts
      */
     public Observable<List<Account>> initiateAccountLinking(final String bankId)
             throws BankAuthorizationRequiredException {
@@ -607,7 +607,7 @@ public class MemberAsync {
      * @param accessToken OAuth access token
      * @return list of linked accounts
      * @throws BankAuthorizationRequiredException if bank authorization payload
-     *                                               is required to link accounts
+     *     is required to link accounts
      */
     public Observable<List<AccountAsync>> linkAccounts(String bankId, String accessToken)
             throws BankAuthorizationRequiredException {

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -29,6 +29,7 @@ import static io.token.TokenIO.TokenCluster.SANDBOX;
 import io.grpc.Metadata;
 import io.grpc.StatusRuntimeException;
 import io.reactivex.functions.Function;
+import io.token.browser.BrowserFactory;
 import io.token.gradle.TokenVersion;
 import io.token.proto.banklink.Banklink.BankAuthorization;
 import io.token.proto.common.alias.AliasProtos.Alias;
@@ -477,6 +478,7 @@ public class TokenIO implements Closeable {
         private long timeoutMs;
         private CryptoEngineFactory cryptoEngine;
         private String devKey;
+        private BrowserFactory browserFactory;
 
         /**
          * Creates new builder instance with the defaults initialized.
@@ -567,6 +569,17 @@ public class TokenIO implements Closeable {
         }
 
         /**
+         * Sets the browser factory to be used with the SDK.
+         *
+         * @param browserFactory browser factory
+         * @return this builder instance
+         */
+        public Builder withBrowserFactory(BrowserFactory browserFactory) {
+            this.browserFactory = browserFactory;
+            return this;
+        }
+
+        /**
          * Builds and returns a new {@link TokenIO} instance.
          *
          * @return {@link TokenIO} instance
@@ -607,7 +620,8 @@ public class TokenIO implements Closeable {
                             ? cryptoEngine
                             : new TokenCryptoEngineFactory(new InMemoryKeyStore()),
                     devKey,
-                    tokenCluster == null ? SANDBOX : tokenCluster);
+                    tokenCluster == null ? SANDBOX : tokenCluster,
+                    browserFactory);
         }
     }
 

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -44,6 +44,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
+import io.token.browser.BrowserFactory;
 import io.token.exceptions.InvalidStateException;
 import io.token.proto.banklink.Banklink.BankAuthorization;
 import io.token.proto.common.alias.AliasProtos.Alias;
@@ -92,7 +93,8 @@ public class TokenIOAsync implements Closeable {
     private final ManagedChannel channel;
     private final CryptoEngineFactory cryptoFactory;
     private final String devKey;
-    private TokenCluster tokenCluster;
+    private final TokenCluster tokenCluster;
+    private final BrowserFactory browserFactory;
 
     /**
      * Creates an instance of a Token SDK.
@@ -106,11 +108,13 @@ public class TokenIOAsync implements Closeable {
             ManagedChannel channel,
             CryptoEngineFactory cryptoFactory,
             String developerKey,
-            TokenCluster tokenCluster) {
+            TokenCluster tokenCluster,
+            BrowserFactory browserFactory) {
         this.channel = channel;
         this.cryptoFactory = cryptoFactory;
         this.devKey = developerKey;
         this.tokenCluster = tokenCluster;
+        this.browserFactory = browserFactory;
     }
 
     @Override
@@ -191,7 +195,11 @@ public class TokenIOAsync implements Closeable {
                                 channel,
                                 member.getId(),
                                 crypto);
-                        return Observable.just(new MemberAsync(member, client, tokenCluster));
+                        return Observable.just(new MemberAsync(
+                                member,
+                                client,
+                                tokenCluster,
+                                browserFactory));
                     }
                 });
     }
@@ -266,7 +274,7 @@ public class TokenIOAsync implements Closeable {
                 .getMember(memberId)
                 .map(new Function<MemberProtos.Member, MemberAsync>() {
                     public MemberAsync apply(MemberProtos.Member member) {
-                        return new MemberAsync(member, client, tokenCluster);
+                        return new MemberAsync(member, client, tokenCluster, browserFactory);
                     }
                 });
     }
@@ -297,7 +305,7 @@ public class TokenIOAsync implements Closeable {
                 .getMember(memberId)
                 .map(new Function<MemberProtos.Member, MemberAsync>() {
                     public MemberAsync apply(MemberProtos.Member member) {
-                        return new MemberAsync(member, client, tokenCluster);
+                        return new MemberAsync(member, client, tokenCluster, browserFactory);
                     }
                 });
     }
@@ -433,7 +441,7 @@ public class TokenIOAsync implements Closeable {
                                 channel,
                                 member.getId(),
                                 cryptoEngine);
-                        return new MemberAsync(member, client, tokenCluster);
+                        return new MemberAsync(member, client, tokenCluster, browserFactory);
                     }
                 });
     }
@@ -460,7 +468,7 @@ public class TokenIOAsync implements Closeable {
                                 channel,
                                 member.getId(),
                                 cryptoEngine);
-                        return new MemberAsync(member, client, tokenCluster);
+                        return new MemberAsync(member, client, tokenCluster, browserFactory);
                     }
                 });
     }

--- a/lib/src/main/java/io/token/rpc/Client.java
+++ b/lib/src/main/java/io/token/rpc/Client.java
@@ -472,7 +472,6 @@ public final class Client {
     /**
      * Links a funding bank account to Token.
      *
-     *
      * @param authorization an authorization to accounts, from the bank
      * @return list of linked accounts
      */
@@ -497,7 +496,7 @@ public final class Client {
      * @param accessToken OAuth access token
      * @return list of linked accounts
      * @throws BankAuthorizationRequiredException if bank authorization payload
-     *                                               is required to link accounts
+     *     is required to link accounts
      */
     public Observable<List<Account>> linkAccounts(String bankId, String accessToken)
             throws BankAuthorizationRequiredException {
@@ -576,7 +575,6 @@ public final class Client {
      *
      * @param payload transfer token payload
      * @param options map of options
-     *
      * @return id to reference token request
      */
     public Observable<String> storeTokenRequest(


### PR DESCRIPTION
- remove param 'browserFactory' from linkAccounts; set in TokenIO instead
- remove param 'bankInfo' from linkAccounts; call getBankInfo within method instead
- move asynchronous linkAccounts to MemberAsync, add synchronous linkAccounts to Member

This method would look much nicer in Java 8... still, suggestions on how to make it less ugly are appreciated.