### PR TITLE
add a method to change browser context in run time

### DIFF
--- a/android/src/main/java/io/token/browser/TokenBrowserFactory.java
+++ b/android/src/main/java/io/token/browser/TokenBrowserFactory.java
@@ -29,13 +29,13 @@ import static io.token.browser.TokenBrowserService.MSG_ON_URL;
 import static io.token.browser.TokenBrowserService.MSG_REGISTER_CLIENT;
 
 public class TokenBrowserFactory implements BrowserFactory {
+    private Context parent;
     private final Map<String, TokenBrowser> browsers;
-    private final Context parent;
     private final MessengerClient messenger;
 
     public TokenBrowserFactory(Context parent) {
-        this.browsers = new HashMap<>();
         this.parent = parent;
+        this.browsers = new HashMap<>();
         this.messenger = new MessengerClient(parent, new IncomingHandler(), null);
     }
 
@@ -54,6 +54,10 @@ public class TokenBrowserFactory implements BrowserFactory {
         parent.startActivity(intent);
 
         return browser;
+    }
+
+    public void setParentContext(Context parent) {
+        this.parent = parent;
     }
 
     private class TokenBrowser implements Browser {

--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.133'
+    version = '1.0.134'
 }


### PR DESCRIPTION
In the previous design, we set the parent context of browser in tokeniobuilder, which will cause problem in old apis. add a method so that android app can change to the correct context for the older apis.