### PR TITLE
Pl 164.keystore

### DIFF
--- a/android/src/androidTest/java/io/token/android/AKSCryptoEngineTest.java
+++ b/android/src/androidTest/java/io/token/android/AKSCryptoEngineTest.java
@@ -1,27 +1,80 @@
 package io.token.android;
 
 import android.content.Context;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.test.mock.MockContext;
+
+import com.google.common.util.concurrent.Uninterruptibles;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.security.AKSCryptoEngineFactory;
+import io.token.security.CryptoEngine;
+import io.token.security.UserAuthenticationStore;
+
+import static io.token.proto.common.security.SecurityProtos.Key.Level.LOW;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 import static org.junit.Assert.*;
 
 /**
  * Instrumented test, which will execute on an Android device.
- * TODO: Add tests for crypto engine
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @RunWith(AndroidJUnit4.class)
 public class AKSCryptoEngineTest {
+    private static final long ONE_DAY = 86400000L;
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 
         assertEquals("io.token.android.test", appContext.getPackageName());
+    }
+
+    @Test
+    public void createSigner_usesValidKey() {
+        CryptoEngine cryptoEngine = new AKSCryptoEngineFactory(
+                new MockContext(),
+                new UserAuthenticationStore(),
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                .create(randomId());
+
+        cryptoEngine.generateKey(LOW, System.currentTimeMillis() + 1000);
+        Key validKey = cryptoEngine.generateKey(LOW, System.currentTimeMillis() + ONE_DAY);
+        Uninterruptibles.sleepUninterruptibly(2000, TimeUnit.MILLISECONDS);
+        assertEquals(cryptoEngine.createSigner(LOW).getKeyId(), validKey.getId());
+
+        Key validStandardKey = cryptoEngine.generateKey(STANDARD);
+        cryptoEngine.generateKey(STANDARD, System.currentTimeMillis() + 1000);
+        Uninterruptibles.sleepUninterruptibly(2000, TimeUnit.MILLISECONDS);
+        assertEquals(cryptoEngine.createSigner(STANDARD).getKeyId(), validStandardKey.getId());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createVerifier_enforcesNonExpired() {
+        CryptoEngine cryptoEngine = new AKSCryptoEngineFactory(
+                new MockContext(),
+                new UserAuthenticationStore(),
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                .create(randomId());
+
+        final Key expiredKey = cryptoEngine.generateKey(
+                STANDARD,
+                System.currentTimeMillis() + 1000);
+        Uninterruptibles.sleepUninterruptibly(2000, TimeUnit.MILLISECONDS);
+        cryptoEngine.createVerifier(expiredKey.getId());
+    }
+
+    private String randomId() {
+        return UUID.randomUUID().toString().replace("-", "");
     }
 }

--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -147,8 +147,12 @@ public final class AKSCryptoEngine implements CryptoEngine {
      */
     @Override
     public Signer createSigner(Key.Level keyLevel) {
+        KeyStore.Entry entry = getKeyFromKeyStore(keyLevel);
+        if (entry == null) {
+            throw new IllegalArgumentException("No key found at level: " + keyLevel);
+        }
         return new AKSSigner(
-                getKeyFromKeyStore(keyLevel),
+                entry,
                 keyLevel,
                 userAuthenticationStore);
     }

--- a/android/src/main/java/io/token/security/AKSVerifier.java
+++ b/android/src/main/java/io/token/security/AKSVerifier.java
@@ -2,6 +2,7 @@ package io.token.security;
 
 import com.google.protobuf.Message;
 import io.token.proto.ProtoJson;
+import io.token.util.codec.ByteEncoding;
 
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
@@ -44,7 +45,10 @@ public class AKSVerifier implements Verifier {
             Signature s = Signature.getInstance("SHA256withECDSA");
             s.initVerify(((PrivateKeyEntry) entry).getCertificate());
             s.update(payload.getBytes("UTF-8"));
-            s.verify(signature.getBytes("UTF-8"));
+            boolean verified = s.verify(ByteEncoding.parse(signature));
+            if (!verified) {
+                throw new InvalidSignatureException("Invalid signature");
+            }
         } catch (InvalidKeyException | NoSuchAlgorithmException | UnsupportedEncodingException ex) {
             throw new RuntimeException(ex);
         } catch (SignatureException ex) {

--- a/lib/src/main/java/io/token/security/CryptoEngine.java
+++ b/lib/src/main/java/io/token/security/CryptoEngine.java
@@ -47,10 +47,10 @@ public interface CryptoEngine {
      * verification later.
      *
      * @param keyLevel key privilege level
-     * @param expirationMs expiration date in milliseconds
+     * @param expiresAtMs expiration date in milliseconds
      * @return newly generated key information
      */
-    Key generateKey(Key.Level keyLevel, long expirationMs);
+    Key generateKey(Key.Level keyLevel, long expiresAtMs);
 
     /**
      * Signs the data with the identified by the supplied key id.

--- a/lib/src/main/java/io/token/security/InMemoryKeyStore.java
+++ b/lib/src/main/java/io/token/security/InMemoryKeyStore.java
@@ -22,15 +22,17 @@
 
 package io.token.security;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import io.token.proto.common.security.SecurityProtos;
+import io.token.util.Clock;
+import io.token.util.SystemTimeClock;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -38,9 +40,25 @@ import java.util.Set;
  */
 public final class InMemoryKeyStore implements KeyStore {
     private final Table<String, String, SecretKey> keys = HashBasedTable.create();
+    private final Clock clock;
+
+    @VisibleForTesting
+    public InMemoryKeyStore(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Creates a new key store.
+     */
+    public InMemoryKeyStore() {
+        this(new SystemTimeClock());
+    }
 
     @Override
     public void put(String memberId, SecretKey key) {
+        if (key.isExpired(clock)) {
+            throw new IllegalArgumentException("Key " + key.getId() + " has expired");
+        }
         keys.put(memberId, key.getId(), key);
     }
 
@@ -48,7 +66,7 @@ public final class InMemoryKeyStore implements KeyStore {
     public SecretKey getByLevel(String memberId, SecurityProtos.Key.Level keyLevel) {
         Collection<SecretKey> memberKeys = keys.row(memberId).values();
         for (SecretKey key : memberKeys) {
-            if (key.getLevel().equals(keyLevel)) {
+            if (key.getLevel().equals(keyLevel) && !key.isExpired(clock)) {
                 return key;
             }
         }
@@ -62,12 +80,22 @@ public final class InMemoryKeyStore implements KeyStore {
         if (key == null) {
             throw new IllegalArgumentException("Key not found for id: " + keyId);
         }
+        if (key.isExpired(clock)) {
+            throw new IllegalArgumentException("Key with id: " + keyId + "has expired");
+        }
+
         return key;
     }
 
     @Override
     public List<SecretKey> listKeys(String memberId) {
-        return new ArrayList<>(keys.row(memberId).values());
+        List<SecretKey> secretKeys = new ArrayList<>();
+        for (SecretKey key : keys.row(memberId).values()) {
+            if (!key.isExpired(clock)) {
+                secretKeys.add(key);
+            }
+        }
+        return secretKeys;
     }
 
     /**

--- a/lib/src/main/java/io/token/security/SecretKey.java
+++ b/lib/src/main/java/io/token/security/SecretKey.java
@@ -24,10 +24,12 @@ package io.token.security;
 
 import com.google.auto.value.AutoValue;
 import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.util.Clock;
 
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates secret key data.
@@ -38,7 +40,29 @@ public abstract class SecretKey {
             String id,
             Key.Level level,
             KeyPair keyPair) {
-        return new AutoValue_SecretKey(id, level, keyPair.getPublic(), keyPair.getPrivate());
+        return new AutoValue_SecretKey(id, level, keyPair.getPublic(), keyPair.getPrivate(), null);
+    }
+
+    /**
+     * Creates an instance of SecretKey.
+     *
+     * @param id key id
+     * @param level key level
+     * @param keyPair key pair
+     * @param expiresAtMs expiration date of the key in milliseconds
+     * @return SecretKey instance
+     */
+    public static SecretKey create(
+            String id,
+            Key.Level level,
+            KeyPair keyPair,
+            @Nullable Long expiresAtMs) {
+        return new AutoValue_SecretKey(
+                id,
+                level,
+                keyPair.getPublic(),
+                keyPair.getPrivate(),
+                expiresAtMs);
     }
 
     public abstract String getId();
@@ -48,4 +72,16 @@ public abstract class SecretKey {
     public abstract PublicKey getPublicKey();
 
     public abstract PrivateKey getPrivateKey();
+
+    @Nullable public abstract Long getExpiresAtMs();
+
+    /**
+     * Checks whether a key has expired against the provided clock.
+     *
+     * @param clock clock
+     * @return true if key has expired
+     */
+    public boolean isExpired(Clock clock) {
+        return getExpiresAtMs() != null && getExpiresAtMs() < clock.getTime();
+    }
 }

--- a/lib/src/main/java/io/token/util/Clock.java
+++ b/lib/src/main/java/io/token/util/Clock.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token.util;
+
+/**
+ * Clock object; used to get current time.
+ */
+public interface Clock {
+    /**
+     * Gets the current time in Epoch milliseconds.
+     *
+     * @return current time
+     */
+    long getTime();
+}

--- a/lib/src/main/java/io/token/util/SystemTimeClock.java
+++ b/lib/src/main/java/io/token/util/SystemTimeClock.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token.util;
+
+public class SystemTimeClock implements Clock {
+    @Override
+    public long getTime() {
+        return System.currentTimeMillis();
+    }
+}

--- a/lib/src/test/java/io/token/security/InMemoryKeyStoreTest.java
+++ b/lib/src/test/java/io/token/security/InMemoryKeyStoreTest.java
@@ -1,8 +1,9 @@
 package io.token.security;
 
+import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.token.proto.common.security.SecurityProtos.Key.Level;
+import io.token.util.Clock;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -11,8 +12,8 @@ import org.junit.Test;
 
 public class InMemoryKeyStoreTest extends KeyStoreTest {
     @Override
-    KeyStore createKeyStore() {
-        return new InMemoryKeyStore();
+    KeyStore createKeyStore(Clock clock) {
+        return new InMemoryKeyStore(clock);
     }
 
     @Test
@@ -23,7 +24,7 @@ public class InMemoryKeyStoreTest extends KeyStoreTest {
 
         InMemoryKeyStore store = new InMemoryKeyStore();
 
-        SecretKey laptop = SecretKey.create("laptop", Level.STANDARD, keyPair);
+        SecretKey laptop = SecretKey.create("laptop", STANDARD, keyPair);
         store.put("steve", laptop);
         assertThat(store.listKeys("steve").size()).isEqualTo(1);
 

--- a/lib/src/test/java/io/token/security/KeyStoreTest.java
+++ b/lib/src/test/java/io/token/security/KeyStoreTest.java
@@ -1,18 +1,33 @@
 package io.token.security;
 
+import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
+import static io.token.util.TimeUtil.daysAfter;
+import static io.token.util.TimeUtil.daysToMs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.token.proto.common.security.SecurityProtos.Key.Level;
+import io.token.util.Clock;
+import io.token.util.TestClock;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 
 abstract class KeyStoreTest {
 
-    abstract KeyStore createKeyStore();
+    abstract KeyStore createKeyStore(Clock clock);
+
+    KeyStore createKeyStore() {
+        return createKeyStore(new TestClock());
+    }
 
     @Test
     public void putThenGet() throws Exception {
@@ -62,5 +77,63 @@ abstract class KeyStoreTest {
                         store.getByLevel("steve", Level.STANDARD);
                     }
                 });
+    }
+
+    @Test
+    public void getExpired() throws Exception {
+        TestClock clock = new TestClock();
+        final KeyStore store = createKeyStore(clock);
+        long now = clock.getTime();
+
+        SecretKey expired = SecretKey.create(
+                "past",
+                STANDARD,
+                generateKeyPair(),
+                daysAfter(now, 1));
+        SecretKey future = SecretKey.create(
+                "future",
+                STANDARD,
+                generateKeyPair(),
+                daysAfter(now, 3));
+        SecretKey noExpiration = SecretKey.create("eternal", STANDARD, generateKeyPair());
+
+        store.put("steve", expired);
+        store.put("steve", future);
+        store.put("steve", noExpiration);
+
+        clock.tick(daysToMs(2));
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                store.getById("steve", "past");
+            }
+        }).hasMessageContaining("has expired");
+        assertThat(store.getById("steve", "eternal")).isEqualTo(noExpiration);
+        assertThat(store.getById("steve", "future")).isEqualTo(future);
+
+        List<SecretKey> keys = store.listKeys("steve");
+        assertThat(keys).containsExactlyInAnyOrder(future, noExpiration);
+
+        now = clock.getTime();
+        SecretKey privilegedExpired = SecretKey.create(
+                "privileged-past",
+                PRIVILEGED,
+                generateKeyPair(),
+                daysAfter(now, 1));
+        store.put("steve", privilegedExpired);
+        clock.tick(daysToMs(2));
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                store.getByLevel("steve", PRIVILEGED);
+            }
+        });
+    }
+
+    private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(1024);
+        return keyGen.genKeyPair();
     }
 }

--- a/lib/src/test/java/io/token/security/TokenCryptoEngineTest.java
+++ b/lib/src/test/java/io/token/security/TokenCryptoEngineTest.java
@@ -1,0 +1,55 @@
+package io.token.security;
+
+import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
+import static io.token.util.TimeUtil.daysAfter;
+import static io.token.util.TimeUtil.daysToMs;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.token.proto.common.security.SecurityProtos;
+import io.token.util.TestClock;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Test;
+
+public class TokenCryptoEngineTest {
+
+    @Test
+    public void createSigner_usesNonExpiredKey() {
+        TestClock clock = new TestClock();
+        KeyStore keyStore = new InMemoryKeyStore(clock);
+        CryptoEngine cryptoEngine = new TokenCryptoEngine("member-id", keyStore);
+        long now = clock.getTime();
+
+        cryptoEngine.generateKey(STANDARD, daysAfter(now, 1));
+        SecurityProtos.Key validKey = cryptoEngine.generateKey(STANDARD, daysAfter(now, 3));
+        clock.tick(daysToMs(2));
+        assertThat(cryptoEngine.createSigner(STANDARD).getKeyId()).isEqualTo(validKey.getId());
+
+        now = clock.getTime();
+        SecurityProtos.Key validPrivilegedKey = cryptoEngine
+                .generateKey(PRIVILEGED, daysAfter(now, 3));
+        cryptoEngine.generateKey(PRIVILEGED, daysAfter(now, 1));
+        clock.tick(daysToMs(2));
+        assertThat(cryptoEngine.createSigner(PRIVILEGED).getKeyId())
+                .isEqualTo(validPrivilegedKey.getId());
+    }
+
+    @Test
+    public void createVerifier_enforcesNonExpired() {
+        TestClock clock = new TestClock();
+        KeyStore keyStore = new InMemoryKeyStore(clock);
+        final CryptoEngine cryptoEngine = new TokenCryptoEngine("member-id", keyStore);
+        long now = clock.getTime();
+
+        final SecurityProtos.Key expiredKey = cryptoEngine.generateKey(STANDARD, daysAfter(now, 1));
+        clock.tick(daysToMs(2));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                new ThrowableAssert.ThrowingCallable() {
+                    @Override
+                    public void call() {
+                        cryptoEngine.createVerifier(expiredKey.getId());
+                    }
+                });
+    }
+}

--- a/lib/src/test/java/io/token/security/UnsecuredFileSystemKeyStoreTest.java
+++ b/lib/src/test/java/io/token/security/UnsecuredFileSystemKeyStoreTest.java
@@ -3,6 +3,7 @@ package io.token.security;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.token.proto.common.security.SecurityProtos.Key.Level;
+import io.token.util.Clock;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -15,8 +16,8 @@ public class UnsecuredFileSystemKeyStoreTest extends KeyStoreTest {
     @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Override
-    KeyStore createKeyStore() {
-        return new UnsecuredFileSystemKeyStore(tempDir.getRoot());
+    KeyStore createKeyStore(Clock clock) {
+        return new UnsecuredFileSystemKeyStore(tempDir.getRoot(), clock);
     }
 
     @Test

--- a/lib/src/test/java/io/token/util/TestClock.java
+++ b/lib/src/test/java/io/token/util/TestClock.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token.util;
+
+public class TestClock implements Clock {
+    private long offset = 0L;
+
+    @Override
+    public long getTime() {
+        return System.currentTimeMillis() + offset;
+    }
+
+    /**
+     * Tick the clock by a specified duration.
+     *
+     * @param duration duration in epoch milliseconds
+     */
+    public void tick(long duration) {
+        offset += duration;
+    }
+}

--- a/lib/src/test/java/io/token/util/TimeUtil.java
+++ b/lib/src/test/java/io/token/util/TimeUtil.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token.util;
+
+public class TimeUtil {
+    /**
+     * Returns the time after a specified number of days.
+     *
+     * @param time the baseline time
+     * @param days number of days
+     * @return time after the inputted days have elapsed
+     */
+    public static long daysAfter(long time, int days) {
+        return time + daysToMs(days);
+    }
+
+    /**
+     * Converts days to milliseconds.
+     *
+     * @param days number of days
+     * @return number of milliseconds
+     */
+    public static long daysToMs(int days) {
+        return 86400000L * days;
+    }
+}

--- a/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
+++ b/samples/src/test/java/io/token/sample/RedeemAccessTokenSampleTest.java
@@ -11,7 +11,6 @@ import static io.token.sample.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.token.AccessTokenBuilder;
-import io.token.Account;
 import io.token.Member;
 import io.token.TokenIO;
 import io.token.proto.MoneyUtil;


### PR DESCRIPTION
For pentesting, we enabled generating keys with expiration dates from the sdk. The KeyStore needs to know which keys are expired so it doesn't return a signer for an expired key, especially when a valid key exists that it could have returned instead. So I am adding clock to the KeyStore using it to filter out expired keys.

The Android crypto engine uses Android API's keystore. Newer versions of the API support key expiration nicely, but for older versions, I've needed to hack-ily encode the expiration date into the "alias" (the identifier for the keypair in the Android keystore). I've separated the logic so that we can just remove the chunks of code that support older versions of the API later on.

NOTE: I made a small change to AKSVerifier because it wasn't working when I tested it at first and I didn't see any uses of it, even in tests. If there are usages, my change will probably break them, so please let me know if this is the case.