### PR TITLE
Pl 1726

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.146'
+    version = '1.0.147'
 }

--- a/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
+++ b/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
@@ -38,7 +38,6 @@ import io.token.TokenRequest;
 import io.token.exceptions.MemberNotFoundException;
 import io.token.exceptions.VerificationException;
 import io.token.proto.banklink.Banklink.BankAuthorization;
-import io.token.proto.common.alias.AliasProtos;
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.bank.BankProtos.Bank;
 import io.token.proto.common.member.MemberProtos.CreateMemberType;
@@ -65,6 +64,8 @@ import io.token.proto.gateway.Gateway.CreateMemberRequest;
 import io.token.proto.gateway.Gateway.CreateMemberResponse;
 import io.token.proto.gateway.Gateway.GetBanksRequest;
 import io.token.proto.gateway.Gateway.GetBanksResponse;
+import io.token.proto.gateway.Gateway.GetDefaultAgentRequest;
+import io.token.proto.gateway.Gateway.GetDefaultAgentResponse;
 import io.token.proto.gateway.Gateway.GetMemberRequest;
 import io.token.proto.gateway.Gateway.GetMemberResponse;
 import io.token.proto.gateway.Gateway.GetTokenIdRequest;
@@ -662,6 +663,21 @@ public final class UnauthenticatedClient {
                     @Override
                     public String apply(GetTokenIdResponse response) throws Exception {
                         return response.getTokenId();
+                    }
+                });
+    }
+
+    /**
+     * Get the default recovery agent id.
+     *
+     * @return the default recovery agent id.
+     */
+    public Observable<String> getDefaultAgent() {
+        return toObservable(gateway.getDefaultAgent(GetDefaultAgentRequest.getDefaultInstance()))
+                .map(new Function<GetDefaultAgentResponse, String>() {
+                    @Override
+                    public String apply(GetDefaultAgentResponse response) throws Exception {
+                        return response.getMemberId();
                     }
                 });
     }

--- a/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
+++ b/lib/src/main/java/io/token/rpc/UnauthenticatedClient.java
@@ -673,11 +673,18 @@ public final class UnauthenticatedClient {
      * @return the default recovery agent id.
      */
     public Observable<String> getDefaultAgent() {
-        return toObservable(gateway.getDefaultAgent(GetDefaultAgentRequest.getDefaultInstance()))
-                .map(new Function<GetDefaultAgentResponse, String>() {
+        // TODO(sibin): Use GetDefaultAgentRequest instead after the call is available.
+        return toObservable(gateway.resolveAlias(
+                ResolveAliasRequest.newBuilder()
+                        .setAlias(Alias.newBuilder()
+                                .setType(Alias.Type.DOMAIN)
+                                .setValue("token.io")
+                                .build())
+                        .build()))
+                .map(new Function<ResolveAliasResponse, String>() {
                     @Override
-                    public String apply(GetDefaultAgentResponse response) throws Exception {
-                        return response.getMemberId();
+                    public String apply(ResolveAliasResponse response) throws Exception {
+                        return response.getMember().getId();
                     }
                 });
     }

--- a/lib/src/main/java/io/token/util/Util.java
+++ b/lib/src/main/java/io/token/util/Util.java
@@ -46,6 +46,8 @@ import io.token.proto.common.member.MemberProtos.MemberAliasOperation;
 import io.token.proto.common.member.MemberProtos.MemberOperation;
 import io.token.proto.common.member.MemberProtos.MemberOperationMetadata;
 import io.token.proto.common.member.MemberProtos.MemberOperationMetadata.AddAliasMetadata;
+import io.token.proto.common.member.MemberProtos.MemberRecoveryRulesOperation;
+import io.token.proto.common.member.MemberProtos.RecoveryRule;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.proto.common.security.SecurityProtos.Signature;
 import io.token.security.KeyNotFoundException;
@@ -114,6 +116,21 @@ public abstract class Util {
                 .setAddKey(MemberAddKeyOperation
                         .newBuilder()
                         .setKey(key))
+                .build();
+    }
+
+    /**
+     * Converts agent id to AddKey operation.
+     *
+     * @param agentId agentId to add
+     * @return member operation
+     */
+    public static MemberOperation toRecoveryAgentOperation(String agentId) {
+        return MemberOperation
+                .newBuilder()
+                .setRecoveryRules(MemberRecoveryRulesOperation
+                        .newBuilder()
+                        .setRecoveryRule(RecoveryRule.newBuilder().setPrimaryAgent(agentId)))
                 .build();
     }
 


### PR DESCRIPTION
Avoid making update member request twice in creating member.
Combine recovery rule operation with keys/alias operations in the same call.