### PR TITLE
RD-306: Downsize generateNonce to fit in the ref id field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.149'
+    version = '1.0.150'
 }

--- a/lib/src/main/java/io/token/TransferTokenBuilder.java
+++ b/lib/src/main/java/io/token/TransferTokenBuilder.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class TransferTokenBuilder {
     private static final Logger logger = LoggerFactory.getLogger(TransferTokenBuilder.class);
+    private static final int REF_ID_MAX_LENGTH = 18;
 
     private final MemberAsync member;
     private final TokenPayload.Builder payload;
@@ -349,6 +350,12 @@ public final class TransferTokenBuilder {
      * @return builder
      */
     public TransferTokenBuilder setRefId(String refId) {
+        if (refId.length() > REF_ID_MAX_LENGTH) {
+            throw new IllegalArgumentException(String.format(
+                    "The length of the refId is at most %s, got: %s",
+                    REF_ID_MAX_LENGTH,
+                    refId.length()));
+        }
         payload.setRefId(refId);
         return this;
     }

--- a/lib/src/main/java/io/token/TransferTokenBuilder.java
+++ b/lib/src/main/java/io/token/TransferTokenBuilder.java
@@ -346,7 +346,7 @@ public final class TransferTokenBuilder {
     /**
      * Sets the referenceId of the token.
      *
-     * @param refId referenceId
+     * @param refId the reference Id, at most 18 characters long
      * @return builder
      */
     public TransferTokenBuilder setRefId(String refId) {

--- a/lib/src/main/java/io/token/util/Util.java
+++ b/lib/src/main/java/io/token/util/Util.java
@@ -87,7 +87,7 @@ public abstract class Util {
      */
     public static final String TOKEN_REALM = "token";
 
-    private static final int NONCE_NUM_BYTES = 20;
+    private static final int NONCE_NUM_BYTES = 12;
 
     private Util() {
     }


### PR DESCRIPTION
The generated nonce's size will be 16~17 characters.

It might seem hacky to change the `generateNonce` call for the ref id field. If we end up having more and more fields with size limitation we can refactor the `generateNonce` call to have an input argument to indicate desired size. This solution works fine for now in my opinion.