### PR TITLE
Expose proto account objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.0.150'
+    version = '1.0.151'
 }

--- a/lib/src/main/java/io/token/Account.java
+++ b/lib/src/main/java/io/token/Account.java
@@ -23,6 +23,7 @@
 package io.token;
 
 import io.token.proto.PagedList;
+import io.token.proto.common.account.AccountProtos;
 import io.token.proto.common.money.MoneyProtos.Money;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.proto.common.transaction.TransactionProtos.Balance;
@@ -114,6 +115,15 @@ public class Account {
      */
     public boolean isLocked() {
         return async.isLocked();
+    }
+
+    /**
+     * Fetches the original {@link AccountProtos.Account} object.
+     *
+     * @return the account.
+     */
+    public AccountProtos.Account protoAccount() {
+        return async.protoAccount();
     }
 
     /**

--- a/lib/src/main/java/io/token/AccountAsync.java
+++ b/lib/src/main/java/io/token/AccountAsync.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  */
 public class AccountAsync {
     private final MemberAsync member;
-    private final AccountProtos.Account.Builder account;
+    private final AccountProtos.Account account;
     private final Client client;
 
     /**
@@ -52,7 +52,7 @@ public class AccountAsync {
      */
     AccountAsync(MemberAsync member, AccountProtos.Account account, Client client) {
         this.member = member;
-        this.account = account.toBuilder();
+        this.account = account;
         this.client = client;
     }
 
@@ -126,6 +126,15 @@ public class AccountAsync {
      */
     public String bankId() {
         return account.getBankId();
+    }
+
+    /**
+     * Fetches the original {@link AccountProtos.Account} object.
+     *
+     * @return the account.
+     */
+    public AccountProtos.Account protoAccount() {
+        return account;
     }
 
     /**
@@ -208,6 +217,6 @@ public class AccountAsync {
         }
 
         AccountAsync other = (AccountAsync) obj;
-        return account.build().equals(other.account.build());
+        return account.equals(other.account);
     }
 }


### PR DESCRIPTION
The `Account` wrapper we have in the SDK doesn't expose all the information that the proto account object has, ie, `AccountFeatures`, `AccountTags`, etc. We would need to update `Account` every time we add something to the proto account object to keep them synced. I am thinking we should expose the proto account object in the `Account` wrapper, so in the wrapper interface we only have frequently/commonly used attributes.

A more immediate use case if that we need to update the merchant-proxy to support data access functionalities, which uses the Java SDK inside. We would need the Java SDK to expose the proto account object so that the merchant-proxy can access all the account information.