### PR TITLE
RD-804

### DIFF
--- a/lib/src/main/java/io/token/DelegateMember.java
+++ b/lib/src/main/java/io/token/DelegateMember.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token;
+
+import io.token.proto.PagedList;
+import io.token.proto.common.member.MemberProtos.AddressRecord;
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.proto.common.transaction.TransactionProtos.Balance;
+import io.token.proto.common.transaction.TransactionProtos.Transaction;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Acts as another member by using a granted access token.
+ */
+public class DelegateMember {
+    private final Member member;
+
+    public DelegateMember(Member member, String tokenId) {
+        this.member = member;
+        this.member.useAccessToken(tokenId);
+    }
+
+    /**
+     * Looks up member addresses.
+     *
+     * @return a list of addresses
+     */
+    public List<AddressRecord> getAddresses() {
+        return member.getAddresses();
+    }
+
+    /**
+     * Looks up an address by id.
+     *
+     * @param addressId the address id
+     * @return an address record
+     */
+    public AddressRecord getAddress(String addressId) {
+        return member.getAddress(addressId);
+    }
+
+    /**
+     * Looks up funding bank accounts linked to Token.
+     *
+     * @return list of linked accounts
+     */
+    public List<Account> getAccounts() {
+        return member.getAccounts();
+    }
+
+    /**
+     * Looks up a funding bank account linked to Token.
+     *
+     * @param accountId account id
+     * @return looked up account
+     */
+    public Account getAccount(String accountId) {
+        return member.getAccount(accountId);
+    }
+
+    /**
+     * Looks up account balance.
+     *
+     * @param accountId account id
+     * @param keyLevel key level
+     * @return balance
+     */
+    public Balance getBalance(String accountId, Key.Level keyLevel) {
+        return member.getBalance(accountId, keyLevel);
+    }
+
+    /**
+     * Looks up transactions for a given account.
+     *
+     * @param accountId the account id
+     * @param offset optional offset to start at
+     * @param limit max number of records to return
+     * @param keyLevel key level
+     * @return paged list of transactions
+     */
+    public PagedList<Transaction, String> getTransactions(
+            String accountId,
+            @Nullable String offset,
+            int limit,
+            Key.Level keyLevel) {
+        return member.getTransactions(accountId, offset, limit, keyLevel);
+    }
+
+    /**
+     * Looks up an existing transaction for a given account.
+     *
+     * @param accountId the account id
+     * @param transactionId ID of the transaction
+     * @param keyLevel key level
+     * @return transaction
+     */
+    public Transaction getTransaction(
+            String accountId,
+            String transactionId,
+            Key.Level keyLevel) {
+        return getTransaction(accountId, transactionId, keyLevel);
+    }
+}

--- a/lib/src/main/java/io/token/DelegateMemberAsync.java
+++ b/lib/src/main/java/io/token/DelegateMemberAsync.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2018 Token, Inc.
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.token;
+
+import io.reactivex.Observable;
+import io.token.proto.PagedList;
+import io.token.proto.common.member.MemberProtos.AddressRecord;
+import io.token.proto.common.security.SecurityProtos.Key;
+import io.token.proto.common.transaction.TransactionProtos.Balance;
+import io.token.proto.common.transaction.TransactionProtos.Transaction;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Acts as another member by using a granted access token.
+ */
+public class DelegateMemberAsync {
+    private final MemberAsync member;
+
+    public DelegateMemberAsync(MemberAsync member, String tokenId) {
+        this.member = member;
+        this.member.useAccessToken(tokenId);
+    }
+
+    /**
+     * Looks up member addresses.
+     *
+     * @return a list of addresses
+     */
+    public Observable<List<AddressRecord>> getAddresses() {
+        return member.getAddresses();
+    }
+
+    /**
+     * Looks up an address by id.
+     *
+     * @param addressId the address id
+     * @return an address record
+     */
+    public Observable<AddressRecord> getAddress(String addressId) {
+        return member.getAddress(addressId);
+    }
+
+    /**
+     * Looks up funding bank accounts linked to Token.
+     *
+     * @return list of linked accounts
+     */
+    public Observable<List<AccountAsync>> getAccounts() {
+        return member.getAccounts();
+    }
+
+    /**
+     * Looks up a funding bank account linked to Token.
+     *
+     * @param accountId account id
+     * @return looked up account
+     */
+    public Observable<AccountAsync> getAccount(String accountId) {
+        return member.getAccount(accountId);
+    }
+
+    /**
+     * Looks up account balance.
+     *
+     * @param accountId account id
+     * @param keyLevel key level
+     * @return balance
+     */
+    public Observable<Balance> getBalance(String accountId, Key.Level keyLevel) {
+        return member.getBalance(accountId, keyLevel);
+    }
+
+    /**
+     * Looks up transactions for a given account.
+     *
+     * @param accountId the account id
+     * @param offset optional offset to start at
+     * @param limit max number of records to return
+     * @param keyLevel key level
+     * @return paged list of transactions
+     */
+    public Observable<PagedList<Transaction, String>> getTransactions(
+            String accountId,
+            @Nullable String offset,
+            int limit,
+            Key.Level keyLevel) {
+        return member.getTransactions(accountId, offset, limit, keyLevel);
+    }
+
+    /**
+     * Looks up an existing transaction for a given account.
+     *
+     * @param accountId the account id
+     * @param transactionId ID of the transaction
+     * @param keyLevel key level
+     * @return transaction
+     */
+    public Observable<Transaction> getTransaction(
+            String accountId,
+            String transactionId,
+            Key.Level keyLevel) {
+        return member.getTransaction(accountId, transactionId, keyLevel);
+    }
+}

--- a/lib/src/main/java/io/token/Member.java
+++ b/lib/src/main/java/io/token/Member.java
@@ -166,6 +166,16 @@ public class Member {
     }
 
     /**
+     * Act as another member using an granted access token.
+     *
+     * @param tokenId the token id
+     * @return a delegate member that acts as the grantor of the access token
+     */
+    public DelegateMember actAs(String tokenId) {
+        return new DelegateMember(this.clone(), tokenId);
+    }
+
+    /**
      * Adds a new alias for the member.
      *
      * @param alias alias, e.g. 'john', must be unique
@@ -1116,6 +1126,11 @@ public class Member {
      */
     public void deleteMember()  {
         async.deleteMember().blockingAwait();
+    }
+
+    @Override
+    protected Member clone() {
+        return new Member(async.clone());
     }
 
     @Override

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -232,6 +232,16 @@ public class MemberAsync {
     }
 
     /**
+     * Act as another member using an granted access token.
+     *
+     * @param tokenId the token id
+     * @return a delegate member that acts as the grantor of the access token
+     */
+    public DelegateMemberAsync actAs(String tokenId) {
+        return new DelegateMemberAsync(this.clone(), tokenId);
+    }
+
+    /**
      * Adds a new alias for the member.
      *
      * @param alias alias, e.g. 'john', must be unique
@@ -1387,6 +1397,11 @@ public class MemberAsync {
      */
     public TokenCluster getTokenCluster() {
         return cluster;
+    }
+
+    @Override
+    protected MemberAsync clone() {
+        return new MemberAsync(member.build(), client.clone(), cluster, browserFactory);
     }
 
     @Override

--- a/lib/src/main/java/io/token/rpc/AuthenticationContext.java
+++ b/lib/src/main/java/io/token/rpc/AuthenticationContext.java
@@ -104,12 +104,10 @@ public class AuthenticationContext {
     /**
      * Retrieves and clears an On-Behalf-Of value.
      *
-     * @return an On-Behalf-Of value or null
      */
-    public static String clearOnBehalfOf() {
-        String tokenId = onBehalfOf.get();
+    public static void clearAccessToken() {
         onBehalfOf.remove();
-        return tokenId;
+        customerInitiated.remove();
     }
 
     /**

--- a/lib/src/main/java/io/token/rpc/Client.java
+++ b/lib/src/main/java/io/token/rpc/Client.java
@@ -202,6 +202,7 @@ public final class Client {
     private final String memberId;
     private final CryptoEngine crypto;
     private final GatewayServiceFutureStub gateway;
+    private boolean customerInitiated = false;
     private String onBehalfOf;
 
     /**
@@ -240,7 +241,7 @@ public final class Client {
      */
     public void useAccessToken(String accessTokenId, boolean customerInitiated) {
         this.onBehalfOf = accessTokenId;
-        AuthenticationContext.setCustomerInitiated(customerInitiated);
+        this.customerInitiated = customerInitiated;
     }
 
     /**
@@ -248,7 +249,7 @@ public final class Client {
      */
     public void clearAccessToken() {
         this.onBehalfOf = null;
-        AuthenticationContext.setCustomerInitiated(false);
+        this.customerInitiated = false;
     }
 
     /**
@@ -1627,9 +1628,15 @@ public final class Client {
         return crypto;
     }
 
+    @Override
+    public Client clone() {
+        return new Client(memberId, crypto, gateway);
+    }
+
     private void setOnBehalfOf() {
         if (onBehalfOf != null) {
             AuthenticationContext.setOnBehalfOf(onBehalfOf);
+            AuthenticationContext.setCustomerInitiated(customerInitiated);
         }
     }
 

--- a/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
+++ b/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
@@ -69,17 +69,14 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
                 Long.toString(now));
         metadata.put(Metadata.Key.of("token-member-id", ASCII_STRING_MARSHALLER), memberId);
 
-        if (AuthenticationContext.getCustomerInitiated()) {
-            metadata.put(
-                    Metadata.Key.of("customer-initiated", ASCII_STRING_MARSHALLER),
-                    Boolean.toString(true));
-        }
-
-        String onBehalfOf = AuthenticationContext.clearOnBehalfOf();
+        String onBehalfOf = AuthenticationContext.getOnBehalfOf();
         if (!Strings.isNullOrEmpty(onBehalfOf)) {
             metadata.put(
                     Metadata.Key.of("token-on-behalf-of", ASCII_STRING_MARSHALLER),
                     onBehalfOf);
+            metadata.put(
+                    Metadata.Key.of("customer-initiated", ASCII_STRING_MARSHALLER),
+                    Boolean.toString(AuthenticationContext.getCustomerInitiated()));
         }
     }
 

--- a/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
+++ b/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
@@ -69,7 +69,7 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
                 Long.toString(now));
         metadata.put(Metadata.Key.of("token-member-id", ASCII_STRING_MARSHALLER), memberId);
 
-        String onBehalfOf = AuthenticationContext.getOnBehalfOf();
+        String onBehalfOf = AuthenticationContext.clearOnBehalfOf();
         if (!Strings.isNullOrEmpty(onBehalfOf)) {
             metadata.put(
                     Metadata.Key.of("token-on-behalf-of", ASCII_STRING_MARSHALLER),

--- a/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
+++ b/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
@@ -69,7 +69,7 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
                 Long.toString(now));
         metadata.put(Metadata.Key.of("token-member-id", ASCII_STRING_MARSHALLER), memberId);
 
-        String onBehalfOf = AuthenticationContext.clearOnBehalfOf();
+        String onBehalfOf = AuthenticationContext.getOnBehalfOf();
         if (!Strings.isNullOrEmpty(onBehalfOf)) {
             metadata.put(
                     Metadata.Key.of("token-on-behalf-of", ASCII_STRING_MARSHALLER),
@@ -77,6 +77,7 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
             metadata.put(
                     Metadata.Key.of("customer-initiated", ASCII_STRING_MARSHALLER),
                     Boolean.toString(AuthenticationContext.getCustomerInitiated()));
+            AuthenticationContext.clearAccessToken();
         }
     }
 


### PR DESCRIPTION
`Member.actAs()` returns a `DelegateMember`
`MemberAsync.actAs()` returns a `DelegateMemberAsync`

I think this wrapper approach logically makes more sense than the interface approach. It would also work with the Javascript SDK so wouldn't need to deal with Javascript not having class hierarchy.

Named the new member as `DelegateMember` because it would still make sense if we decided to add more power to access tokens later.
