### PR TITLE
TokenActivity emits onComplete on browser back button

### DIFF
--- a/android/src/main/java/io/token/browser/TokenBrowserActivity.java
+++ b/android/src/main/java/io/token/browser/TokenBrowserActivity.java
@@ -14,6 +14,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import static io.token.browser.TokenBrowserService.MSG_CLOSE;
+import static io.token.browser.TokenBrowserService.MSG_COMPLETE;
 import static io.token.browser.TokenBrowserService.MSG_GO_TO;
 import static io.token.browser.TokenBrowserService.MSG_KEY_SID;
 import static io.token.browser.TokenBrowserService.MSG_KEY_URL;
@@ -71,6 +72,13 @@ public class TokenBrowserActivity extends Activity {
     }
 
     @Override
+    public void onBackPressed() {
+        Bundle data = new Bundle(1);
+        data.putString(MSG_KEY_SID, sessionId);
+        messenger.send(MSG_COMPLETE, data);
+    }
+
+    @Override
     protected void onStop() {
         super.onStop();
         messenger.stop();
@@ -83,7 +91,7 @@ public class TokenBrowserActivity extends Activity {
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig){
+    public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
     }
 

--- a/android/src/main/java/io/token/browser/TokenBrowserFactory.java
+++ b/android/src/main/java/io/token/browser/TokenBrowserFactory.java
@@ -22,11 +22,13 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.Subject;
 
 import static io.token.browser.TokenBrowserService.MSG_CLOSE;
+import static io.token.browser.TokenBrowserService.MSG_COMPLETE;
 import static io.token.browser.TokenBrowserService.MSG_GO_TO;
 import static io.token.browser.TokenBrowserService.MSG_KEY_SID;
 import static io.token.browser.TokenBrowserService.MSG_KEY_URL;
 import static io.token.browser.TokenBrowserService.MSG_ON_URL;
 import static io.token.browser.TokenBrowserService.MSG_REGISTER_CLIENT;
+import static io.token.browser.TokenBrowserService.MSG_UNREGISTER_CLIENT;
 
 public class TokenBrowserFactory implements BrowserFactory {
     private Context parent;
@@ -141,6 +143,11 @@ public class TokenBrowserFactory implements BrowserFactory {
                         browser.onUrl(url);
                     }
                     break;
+                case MSG_COMPLETE:
+                    browser = browsers.get(sessionId);
+                    if (browser != null) {
+                        browser.close();
+                    }
                 default:
                     super.handleMessage(msg);
             }

--- a/android/src/main/java/io/token/browser/TokenBrowserService.java
+++ b/android/src/main/java/io/token/browser/TokenBrowserService.java
@@ -18,6 +18,7 @@ public class TokenBrowserService extends Service {
     static final int MSG_ON_URL = 3;
     static final int MSG_CLOSE = 4;
     static final int MSG_GO_TO = 5;
+    static final int MSG_COMPLETE = 6;
     static final String MSG_KEY_SID = "SID";
     static final String MSG_KEY_URL = "URL";
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.1.3'
+    version = '1.1.4'
 }

--- a/lib/src/main/java/io/token/MemberAsync.java
+++ b/lib/src/main/java/io/token/MemberAsync.java
@@ -39,6 +39,7 @@ import io.reactivex.ObservableSource;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
+import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
@@ -93,6 +94,7 @@ import io.token.util.Util;
 
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -582,6 +584,7 @@ public class MemberAsync implements RepresentableAsync {
 
     /**
      * Links accounts by navigating browser through bank authorization pages.
+     * Returns empty list if the linking process is cancelled from the browser.
      *
      * @param bankId the bank id
      * @return observable list of linked accounts
@@ -639,6 +642,12 @@ public class MemberAsync implements RepresentableAsync {
                                                     public void accept(Throwable ex) {
                                                         emitter.onError(ex);
                                                         browser.close();
+                                                    }
+                                                },
+                                                new Action() {
+                                                    @Override
+                                                    public void run() {
+                                                        emitter.onSuccess(Collections.EMPTY_LIST);
                                                     }
                                                 });
                                 String linkingUrl = bankInfo.getBankLinkingUri();


### PR DESCRIPTION
Pressing the back button will now do the exact same thing as if the user manually closes the browser. (That is, close the activity and emit onComplete.) Is this the desired behavior @sibinlu ?