### PR TITLE
fix create signer latency

### DIFF
--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -215,11 +215,11 @@ public final class AKSCryptoEngine implements CryptoEngine {
             Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 String alias = aliases.nextElement();
-                KeyStore.Entry entry = keyStore.getEntry(alias, null);
-                if (!(entry instanceof KeyStore.PrivateKeyEntry)) {
-                    throw new RuntimeException("Invalid private key");
-                }
                 if (alias.startsWith(getAliasPrefix(keyLevel)) && !isExpired(alias)) {
+                    KeyStore.Entry entry = keyStore.getEntry(alias, null);
+                    if (!(entry instanceof KeyStore.PrivateKeyEntry)) {
+                        throw new RuntimeException("Invalid private key");
+                    }
                     return entry;
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.1.10'
+    version = '1.1.11'
 }


### PR DESCRIPTION
GetEntry time is not ignorable in aks key store. Re-order the code to avoid unnecessary codes.