### PR TITLE
remove deprecated login methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 If you're upgrading to a new version of the SDK,
 see this list for Java APIs that have changed:
 
+## Release 1.1.23
+
+The `login` methods in TokenIO and TokenIOAsync were removed.
+
 ## Release 1.0.84
 
 The `login` methods in TokenIO and TokenIOAsync were renamed to `getMember`.

--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '1.1.22'
+    version = '1.1.23'
 }

--- a/lib/src/main/java/io/token/TokenIO.java
+++ b/lib/src/main/java/io/token/TokenIO.java
@@ -272,20 +272,6 @@ public class TokenIO implements Closeable {
     }
 
     /**
-     * Return a MemberAsync set up to use some Token member's keys (assuming we have them).
-     *
-     * @param memberId member id
-     * @return member
-     * @deprecated login's name changed to getMember
-     */
-    @Deprecated
-    public Member login(String memberId) {
-        return async.getMember(memberId)
-                .map(new MemberFunction())
-                .blockingSingle();
-    }
-
-    /**
      * Notifies to link accounts.
      *
      * @param alias alias to notify

--- a/lib/src/main/java/io/token/TokenIOAsync.java
+++ b/lib/src/main/java/io/token/TokenIOAsync.java
@@ -361,26 +361,6 @@ public class TokenIOAsync implements Closeable {
     }
 
     /**
-     * Return a Member set up to use some Token member's keys (assuming we have them).
-     *
-     * @param memberId member id
-     * @return member
-     * @deprecated login's name changed to getMember
-     */
-    @Deprecated
-    public Observable<MemberAsync> login(String memberId) {
-        CryptoEngine crypto = cryptoFactory.create(memberId);
-        final Client client = ClientFactory.authenticated(channel, memberId, crypto);
-        return client
-                .getMember(memberId)
-                .map(new Function<MemberProtos.Member, MemberAsync>() {
-                    public MemberAsync apply(MemberProtos.Member member) {
-                        return new MemberAsync(member, client, tokenCluster, browserFactory);
-                    }
-                });
-    }
-
-    /**
      * Notifies to link an account.
      *
      * @param alias alias to notify


### PR DESCRIPTION
It has been more than 10 months since the methods were deprecated.