### PR TITLE
update rpc version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ buildscript {
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.1.55',
-            tokenRpc             : '1.1.19',
-            tokenSecurity        : '1.1.5',
+            tokenProto           : '1.1.56',
+            tokenRpc             : '1.1.25',
+            tokenSecurity        : '1.1.6',
             rxjava               : '2.1.1',
         ]
     }
 
     group = 'io.token.sdk'
-    version = '1.1.35'
+    version = '1.1.36'
 }

--- a/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
+++ b/lib/src/main/java/io/token/rpc/ClientAuthenticator.java
@@ -25,9 +25,9 @@ package io.token.rpc;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import static io.token.proto.ProtoJson.toJson;
 import static io.token.rpc.ContextKeys.SECURITY_METADATA_KEY;
-import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 
 import com.google.common.base.Strings;
+import com.google.common.io.BaseEncoding;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import io.grpc.Metadata;
@@ -78,7 +78,8 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
         metadata.put(Metadata.Key.of("token-member-id", ASCII_STRING_MARSHALLER), memberId);
         metadata.put(
                 SECURITY_METADATA_KEY.getMetadataKey(),
-                encodeBase64String(toJson(authenticationContext.getSecurityMetadata()).getBytes()));
+                BaseEncoding.base64().encode(
+                        toJson(authenticationContext.getSecurityMetadata()).getBytes()));
 
         String onBehalfOf = authenticationContext.getOnBehalfOf();
         if (!Strings.isNullOrEmpty(onBehalfOf)) {


### PR DESCRIPTION
org.apache.commons.codec.binary.Base64. is not available after updating to the new rpc lib.
Use google BaseEncoding instead.