### PR TITLE
add redeemToken convenience methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ buildscript {
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.1.100',
-            tokenRpc             : '1.1.36',
+            tokenProto           : '1.1.104',
+            tokenRpc             : '1.1.44',
             tokenSecurity        : '1.1.6',
             rxjava               : '2.1.1',
         ]
     }
 
     group = 'io.token.sdk'
-    version = '2.0.4-beta-12'
+    version = '2.0.4-beta-13'
 }

--- a/tpp/src/main/java/io/token/tpp/Member.java
+++ b/tpp/src/main/java/io/token/tpp/Member.java
@@ -450,6 +450,25 @@ public class Member extends io.token.Member implements Representable {
      * @param amount transfer amount
      * @param currency transfer currency code, e.g. "EUR"
      * @param description transfer description
+     * @param refId transfer reference id
+     * @return transfer record
+     */
+    public Observable<Transfer> redeemToken(
+            Token token,
+            @Nullable Double amount,
+            @Nullable String currency,
+            @Nullable String description,
+            @Nullable String refId) {
+        return redeemTokenInternal(token, amount, currency, description, null, refId);
+    }
+
+    /**
+     * Redeems a transfer token.
+     *
+     * @param token transfer token to redeem
+     * @param amount transfer amount
+     * @param currency transfer currency code, e.g. "EUR"
+     * @param description transfer description
      * @param destination the transfer instruction destination
      * @param refId transfer reference id
      * @return transfer record
@@ -717,6 +736,25 @@ public class Member extends io.token.Member implements Representable {
             @Nullable TransferEndpoint destination) {
         return redeemToken(token, amount, currency, description, destination)
                 .blockingSingle();
+    }
+
+    /**
+     * Redeems a transfer token.
+     *
+     * @param token transfer token to redeem
+     * @param amount transfer amount
+     * @param currency transfer currency code, e.g. "EUR"
+     * @param description transfer description
+     * @param refId transfer reference id
+     * @return transfer record
+     */
+    public Transfer redeemTokenBlocking(
+            Token token,
+            @Nullable Double amount,
+            @Nullable String currency,
+            @Nullable String description,
+            @Nullable String refId) {
+        return redeemToken(token, amount, currency, description, refId).blockingSingle();
     }
 
     /**

--- a/user/src/main/java/io/token/user/Member.java
+++ b/user/src/main/java/io/token/user/Member.java
@@ -909,6 +909,25 @@ public class Member extends io.token.Member {
      * @param amount transfer amount
      * @param currency transfer currency code, e.g. "EUR"
      * @param description transfer description
+     * @param refId transfer reference id
+     * @return transfer record
+     */
+    public Observable<Transfer> redeemToken(
+            Token token,
+            @Nullable Double amount,
+            @Nullable String currency,
+            @Nullable String description,
+            @Nullable String refId) {
+        return redeemTokenInternal(token, amount, currency, description, null, refId);
+    }
+
+    /**
+     * Redeems a transfer token.
+     *
+     * @param token transfer token to redeem
+     * @param amount transfer amount
+     * @param currency transfer currency code, e.g. "EUR"
+     * @param description transfer description
      * @param destination the transfer instruction destination
      * @param refId transfer reference id
      * @return transfer record
@@ -1176,6 +1195,25 @@ public class Member extends io.token.Member {
             @Nullable TransferEndpoint destination) {
         return redeemToken(token, amount, currency, description, destination)
                 .blockingSingle();
+    }
+
+    /**
+     * Redeems a transfer token.
+     *
+     * @param token transfer token to redeem
+     * @param amount transfer amount
+     * @param currency transfer currency code, e.g. "EUR"
+     * @param description transfer description
+     * @param refId transfer reference id
+     * @return transfer record
+     */
+    public Transfer redeemTokenBlocking(
+            Token token,
+            @Nullable Double amount,
+            @Nullable String currency,
+            @Nullable String description,
+            @Nullable String refId) {
+        return redeemToken(token, amount, currency, description, refId).blockingSingle();
     }
 
     /**


### PR DESCRIPTION
so that you can pass null in for List(TransferEndpoint) / List(TransferEndpoint) without matching multiple methods.