### PR TITLE
update the endpoint for createTransferTokenBuilder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '2.1.5'
+    version = '2.1.6'
 }

--- a/user/src/main/java/io/token/user/Member.java
+++ b/user/src/main/java/io/token/user/Member.java
@@ -430,6 +430,7 @@ public class Member extends io.token.Member {
      * @param currency currency code, e.g. "USD"
      * @return transfer token builder
      */
+    @Deprecated
     public TransferTokenBuilder createTransferToken(double amount, String currency) {
         return createTransferTokenBuilder(amount, currency);
     }
@@ -442,6 +443,7 @@ public class Member extends io.token.Member {
      * @param tokenRequest token request
      * @return transfer token builder
      */
+    @Deprecated
     public TransferTokenBuilder createTransferToken(TokenRequest tokenRequest) {
         return createTransferTokenBuilder(tokenRequest);
     }
@@ -481,6 +483,7 @@ public class Member extends io.token.Member {
      * @param tokenRequest token request
      * @return transfer token builder
      */
+    @Deprecated
     public TransferTokenBuilder createTransferTokenBlocking(TokenRequest tokenRequest) {
         return createTransferToken(tokenRequest);
     }

--- a/user/src/main/java/io/token/user/Member.java
+++ b/user/src/main/java/io/token/user/Member.java
@@ -397,7 +397,7 @@ public class Member extends io.token.Member {
      * @param currency currency code, e.g. "USD"
      * @return transfer token builder
      */
-    public TransferTokenBuilder createTransferToken(double amount, String currency) {
+    public TransferTokenBuilder createTransferTokenBuilder(double amount, String currency) {
         return new TransferTokenBuilder(this, amount, currency);
     }
 
@@ -407,8 +407,43 @@ public class Member extends io.token.Member {
      * @param tokenRequest token request
      * @return transfer token builder
      */
-    public TransferTokenBuilder createTransferToken(TokenRequest tokenRequest) {
+    public TransferTokenBuilder createTransferTokenBuilder(TokenRequest tokenRequest) {
         return new TransferTokenBuilder(this, tokenRequest);
+    }
+
+    /**
+     * Creates a new transfer token builder from a token payload.
+     *
+     * @param tokenPayload token payload
+     * @return transfer token builder
+     */
+    public TransferTokenBuilder createTransferTokenBuilder(TokenPayload tokenPayload) {
+        return new TransferTokenBuilder(this, tokenPayload);
+    }
+
+    /**
+     * DEPRECATED: Use {@link Member#createTransferTokenBuilder(double, String)} instead.
+     *
+     * <p>Creates a new transfer token builder.
+     *
+     * @param amount transfer amount
+     * @param currency currency code, e.g. "USD"
+     * @return transfer token builder
+     */
+    public TransferTokenBuilder createTransferToken(double amount, String currency) {
+        return createTransferTokenBuilder(amount, currency);
+    }
+
+    /**
+     * DEPRECATED: Use {@link Member#createTransferTokenBuilder(TokenRequest)} instead.
+     *
+     * <p>Creates a new transfer token builder from a token request.
+     *
+     * @param tokenRequest token request
+     * @return transfer token builder
+     */
+    public TransferTokenBuilder createTransferToken(TokenRequest tokenRequest) {
+        return createTransferTokenBuilder(tokenRequest);
     }
 
     /**
@@ -439,7 +474,9 @@ public class Member extends io.token.Member {
     }
 
     /**
-     * Creates a new transfer token builder from a token request.
+     * DEPRECATED: Use {@link Member#createTransferTokenBuilder(TokenRequest)} instead.
+     *
+     * <p>Creates a new transfer token builder from a token request.
      *
      * @param tokenRequest token request
      * @return transfer token builder

--- a/user/src/main/java/io/token/user/Member.java
+++ b/user/src/main/java/io/token/user/Member.java
@@ -1821,4 +1821,23 @@ public class Member extends io.token.Member {
                     }
                 });
     }
+
+    /**
+     * Sets the app's callback url.
+     *
+     * @param appCallbackUrl the app callback url to set
+     * @return completable
+     */
+    public Completable setAppCallbackUrl(String appCallbackUrl) {
+        return client.setAppCallbackUrl(appCallbackUrl);
+    }
+
+    /**
+     * Sets the app's callback url.
+     *
+     * @param appCallbackUrl the app callback url to set
+     */
+    public void setAppCallbackUrlBlocking(String appCallbackUrl) {
+        client.setAppCallbackUrl(appCallbackUrl).blockingAwait();
+    }
 }

--- a/user/src/main/java/io/token/user/rpc/Client.java
+++ b/user/src/main/java/io/token/user/rpc/Client.java
@@ -799,6 +799,20 @@ public final class Client extends io.token.rpc.Client {
                         .build()));
     }
 
+    /**
+     * Sets the app's callback url.
+     *
+     * @param appCallbackUrl the app callback url to set
+     * @return completable
+     */
+    public Completable setAppCallbackUrl(String appCallbackUrl) {
+        return toCompletable(gateway
+                .withAuthentication(authenticationContext())
+                .setAppCallbackUrl(Gateway.SetAppCallbackUrlRequest.newBuilder()
+                        .setAppCallbackUrl(appCallbackUrl)
+                        .build()));
+    }
+
     private Observable<TokenOperationResult> cancelAndReplace(
             Token tokenToCancel,
             CreateToken.Builder createToken) {


### PR DESCRIPTION
1. rename to createTransferTokenBuilder which makes more sense.
2. Add endpoint for createTransferTokenBuilder(TokenPayload)
3. From information is optional in TokenRequest and TokenPayload theoretically. If it doesn't present we can fill it with the member.