### PR TITLE
RD-798: upgrade gradle and java + dependencies + add keepalive-s

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 26
@@ -135,3 +134,5 @@ signing {
     required { project.hasProperty('signing.keyId') }
     sign configurations.archives
 }
+
+apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -10,27 +10,26 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'io.token.gradle:token-gradle:1.1.8'
+        classpath 'io.token.gradle:token-gradle:1.1.12'
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.21'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4'
-        classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.google.code.gson:gson:2.8.2'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.9.7'
+        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.google.code.gson:gson:2.8.5'
     }
 }
 
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.1.119',
-            tokenRpc             : '1.1.44',
-            tokenSecurity        : '1.1.7',
+            tokenProto           : '1.1.120',
+            tokenRpc             : '1.1.45',
+            tokenSecurity        : '1.1.13',
             rxjava               : '2.1.1',
         ]
     }
 
     group = 'io.token.sdk'
-    version = '2.1.8'
+    version = '2.2.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip


### PR DESCRIPTION
Not sure about bumping minor version. It looks like a pretty big jump in dependencies to me, so I won't be surprised that some our users would have problems with using this SDK (though it builds correctly to me without any changes).
If you think that we should just bump patch version, we can bump it instead of minor version.

P.S. @sibinlu com.github.dcendents:anrdoid-maven plugin is abandoned and won't work with gradle 5+ (see https://github.com/dcendents/android-maven-gradle-plugin) so it was replaced with https://github.com/sky-uk/gradle-maven-plugin.