### PR TITLE
use empty string instead of null in mapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '2.3.9'
+    version = '2.3.10'
 }

--- a/user/src/main/java/io/token/user/Member.java
+++ b/user/src/main/java/io/token/user/Member.java
@@ -1467,9 +1467,9 @@ public class Member extends io.token.Member {
                         throw new Exception("Bank linking error: " + error);
                     }
                     browser.goTo(url);
-                    return null;
+                    return "";
                 })
-                .filter(accessToken -> accessToken != null)
+                .filter(accessToken -> !accessToken.isEmpty())
                 .flatMap(accessToken -> linkAccounts(bankId, accessToken));
 
         return getBankInfo(bankId)


### PR DESCRIPTION
1. Optional is not supported in Android API level 23
2. Mapper in Rxjava 2 don't support null.

So I decide to use an empty string for now