### PR TITLE
fix unexpected null pointer exception

### DIFF
--- a/android/src/main/java/io/token/security/AKSCryptoEngine.java
+++ b/android/src/main/java/io/token/security/AKSCryptoEngine.java
@@ -457,7 +457,12 @@ public final class AKSCryptoEngine implements CryptoEngine {
             Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 String alias = aliases.nextElement();
-                if (getMemberId(alias).equals(memberId)) {
+                String mId = getMemberId(alias);
+                if (mId == null) {
+                    // It is not an alias that token can recognize.
+                    continue;
+                }
+                if (mId.equals(memberId)) {
                     keyStore.deleteEntry(alias);
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '2.5.2'
+    version = '2.5.3'
 }


### PR DESCRIPTION
key store is a share storage. We should not throw NullPointerException if we can not parse the member id from the key alias.