### PR TITLE
PLT-109: add registerWithEidas call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,3 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 /classes/
-
-build/
-log/
-out/
-classes/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 .idea
 build/
 log/
+core/out/
+tpp-sample/out/
+tpp/out/
+user-sample/out/
+user/out/
 keys/
 /lib/out
 **/*.iml
@@ -21,3 +26,8 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 /classes/
+
+build/
+log/
+out/
+classes/

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '2.9.3'
+    version = '2.9.4'
 }

--- a/core/src/main/java/io/token/exceptions/KeyNotFoundException.java
+++ b/core/src/main/java/io/token/exceptions/KeyNotFoundException.java
@@ -20,45 +20,24 @@
  * THE SOFTWARE.
  */
 
-package io.token.security;
+package io.token.exceptions;
 
-import static io.token.security.TokenCryptoEngine.DEFAULT_CRYPTO_TYPE;
+import io.token.proto.common.security.SecurityProtos;
 
-import io.token.security.crypto.CryptoType;
-
-/**
- * Creates {@link CryptoEngine} instances bound to a given member id.
- * Uses a provided key store to persist keys.
- */
-public class TokenCryptoEngineFactory implements CryptoEngineFactory {
-    private final KeyStore keyStore;
-    private final CryptoType cryptoType;
-
-
-    /**
-     * Creates a new instance of the factory that uses supplied store
-     * to persist the keys.
-     *
-     * @param keyStore key store
-     */
-    public TokenCryptoEngineFactory(KeyStore keyStore) {
-        this.keyStore = keyStore;
-        this.cryptoType = DEFAULT_CRYPTO_TYPE;
+public class KeyNotFoundException extends IllegalArgumentException {
+    public KeyNotFoundException(String msg) {
+        super(msg);
     }
 
-    public TokenCryptoEngineFactory(KeyStore keyStore, CryptoType cryptoType) {
-        this.keyStore = keyStore;
-        this.cryptoType = cryptoType;
+    public static KeyNotFoundException keyNotFoundForLevel(SecurityProtos.Key.Level keyLevel) {
+        return new KeyNotFoundException("Key not found for level: " + keyLevel);
     }
 
-    /**
-     * Creates a new {@link CryptoEngine} for the given member.
-     *
-     * @param memberId member id
-     * @return crypto engine instance
-     */
-    @Override
-    public CryptoEngine create(String memberId) {
-        return new TokenCryptoEngine(memberId, keyStore, cryptoType);
+    public static KeyNotFoundException keyNotFoundForId(String keyId) {
+        return new KeyNotFoundException("Key not found for id: " + keyId);
+    }
+
+    public static KeyNotFoundException keyExpired(String keyId) {
+        return new KeyNotFoundException("Key with id: " + keyId + "has expired");
     }
 }

--- a/core/src/main/java/io/token/exceptions/KeyNotFoundException.java
+++ b/core/src/main/java/io/token/exceptions/KeyNotFoundException.java
@@ -25,7 +25,7 @@ package io.token.exceptions;
 import io.token.proto.common.security.SecurityProtos;
 
 public class KeyNotFoundException extends IllegalArgumentException {
-    public KeyNotFoundException(String msg) {
+    KeyNotFoundException(String msg) {
         super(msg);
     }
 
@@ -39,5 +39,9 @@ public class KeyNotFoundException extends IllegalArgumentException {
 
     public static KeyNotFoundException keyExpired(String keyId) {
         return new KeyNotFoundException("Key with id: " + keyId + "has expired");
+    }
+
+    public static KeyNotFoundException keyNotFound(String message) {
+        return new KeyNotFoundException("Key not found: " + message);
     }
 }

--- a/core/src/main/java/io/token/rpc/ClientAuthenticator.java
+++ b/core/src/main/java/io/token/rpc/ClientAuthenticator.java
@@ -31,10 +31,8 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import io.grpc.Metadata;
-import io.token.exceptions.KeyNotFoundException;
 import io.token.proto.common.security.SecurityProtos.CustomerTrackingMetadata;
 import io.token.proto.common.security.SecurityProtos.Key;
-import io.token.proto.common.security.SecurityProtos.Key.Level;
 import io.token.proto.gateway.Auth.GrpcAuthPayload;
 import io.token.rpc.interceptor.SimpleInterceptor;
 import io.token.security.CryptoEngine;
@@ -66,7 +64,7 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
                 .setCreatedAtMs(now)
                 .build();
         Key.Level keyLevel = authenticationContext.getKeyLevel();
-        Signer signer = createSigner(keyLevel);
+        Signer signer = crypto.createSignerForLevelAtLeast(keyLevel);
         String signature = signer.sign(payload);
 
         metadata.put(Metadata.Key.of("token-realm", ASCII_STRING_MARSHALLER), "Token");
@@ -105,18 +103,5 @@ final class ClientAuthenticator<ReqT, ResT> extends SimpleInterceptor<ReqT, ResT
     @Override
     public void onHalfClose(ReqT req, Metadata headers) {
         // Ignore
-    }
-
-    private Signer createSigner(Level minKeyLevel) {
-        Level keyLevel = minKeyLevel;
-        while (keyLevel.getNumber() > 0) {
-            try {
-                return crypto.createSigner(keyLevel);
-            } catch (KeyNotFoundException e) {
-                // try a key for the next level
-                keyLevel = Level.forNumber(keyLevel.getNumber() - 1);
-            }
-        }
-        throw new KeyNotFoundException("Key not found for level " + minKeyLevel + " or higher.");
     }
 }

--- a/core/src/main/java/io/token/security/CryptoEngine.java
+++ b/core/src/main/java/io/token/security/CryptoEngine.java
@@ -22,6 +22,9 @@
 
 package io.token.security;
 
+import static io.token.exceptions.KeyNotFoundException.keyNotFoundForLevel;
+
+import io.token.exceptions.KeyNotFoundException;
 import io.token.proto.common.security.SecurityProtos.Key;
 
 import java.util.List;
@@ -50,6 +53,28 @@ public interface CryptoEngine {
      * @return newly generated key information
      */
     Key generateKey(Key.Level keyLevel, long expiresAtMs);
+
+    /**
+     * Creates a new signer that uses a key of specified level or higher (if no key of the
+     * specified level can be found).<br>
+     * Note, that if there are several same-level keys, a random one is used to create a signer.
+     * If you need to create a signer for a specific key, create a signer using the key id.
+     *
+     * @param minKeyLevel minimum level of the key to use
+     * @return signer that is used to generate digital signatures
+     */
+    default Signer createSignerForLevelAtLeast(Key.Level minKeyLevel) {
+        Key.Level keyLevel = minKeyLevel;
+        while (keyLevel.getNumber() > 0) {
+            try {
+                return createSigner(keyLevel);
+            } catch (KeyNotFoundException e) {
+                // try a key for the next level
+                keyLevel = Key.Level.forNumber(keyLevel.getNumber() - 1);
+            }
+        }
+        throw keyNotFoundForLevel(minKeyLevel);
+    }
 
     /**
      * Creates a new signer that uses a key of specified level.<br>

--- a/core/src/main/java/io/token/security/InMemoryKeyStore.java
+++ b/core/src/main/java/io/token/security/InMemoryKeyStore.java
@@ -22,6 +22,10 @@
 
 package io.token.security;
 
+import static io.token.exceptions.KeyNotFoundException.keyExpired;
+import static io.token.exceptions.KeyNotFoundException.keyNotFoundForId;
+import static io.token.exceptions.KeyNotFoundException.keyNotFoundForLevel;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
@@ -57,7 +61,7 @@ public final class InMemoryKeyStore implements KeyStore {
     @Override
     public void put(String memberId, SecretKey key) {
         if (key.isExpired(clock)) {
-            throw new IllegalArgumentException("Key " + key.getId() + " has expired");
+            throw keyExpired(key.getId());
         }
         keys.put(memberId, key.getId(), key);
     }
@@ -70,7 +74,7 @@ public final class InMemoryKeyStore implements KeyStore {
                 return key;
             }
         }
-        throw new IllegalArgumentException("Key not found for level: " + keyLevel);
+        throw keyNotFoundForLevel(keyLevel);
     }
 
     @Override
@@ -78,10 +82,10 @@ public final class InMemoryKeyStore implements KeyStore {
         SecretKey key = keys.get(memberId, keyId);
 
         if (key == null) {
-            throw new IllegalArgumentException("Key not found for id: " + keyId);
+            throw keyNotFoundForId(keyId);
         }
         if (key.isExpired(clock)) {
-            throw new IllegalArgumentException("Key with id: " + keyId + "has expired");
+            throw keyExpired(keyId);
         }
 
         return key;

--- a/core/src/main/java/io/token/security/KeyStore.java
+++ b/core/src/main/java/io/token/security/KeyStore.java
@@ -23,6 +23,7 @@
 package io.token.security;
 
 import io.token.exceptions.KeyIOException;
+import io.token.exceptions.KeyNotFoundException;
 import io.token.proto.common.security.SecurityProtos;
 
 import java.util.List;
@@ -47,6 +48,7 @@ public interface KeyStore {
      * @param keyLevel {@link SecurityProtos.Key.Level} of the key to get
      * @return secret key
      * @throws KeyIOException if an error is encountered while fetching the key
+     * @throws KeyNotFoundException if the key cannot be found
      */
     SecretKey getByLevel(String memberId, SecurityProtos.Key.Level keyLevel);
 
@@ -57,6 +59,7 @@ public interface KeyStore {
      * @param keyId key ID to get
      * @return secret key
      * @throws KeyIOException if an error is encountered while fetching the key
+     * @throws KeyNotFoundException if the key cannot be found or expired
      */
     SecretKey getById(String memberId, String keyId);
 

--- a/core/src/main/java/io/token/security/UnsecuredFileSystemKeyStore.java
+++ b/core/src/main/java/io/token/security/UnsecuredFileSystemKeyStore.java
@@ -23,6 +23,7 @@
 package io.token.security;
 
 import static io.token.exceptions.KeyNotFoundException.keyExpired;
+import static io.token.exceptions.KeyNotFoundException.keyNotFound;
 import static io.token.exceptions.KeyNotFoundException.keyNotFoundForLevel;
 
 import com.google.bitcoin.core.AddressFormatException;
@@ -35,7 +36,6 @@ import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.token.exceptions.KeyIOException;
-import io.token.exceptions.KeyNotFoundException;
 import io.token.proto.common.security.SecurityProtos.Key;
 import io.token.proto.common.security.SecurityProtos.Key.Level;
 import io.token.util.Clock;
@@ -160,7 +160,7 @@ public final class UnsecuredFileSystemKeyStore implements KeyStore {
         try {
             return codec.decode(keyFile.getName(), Files.toString(keyFile, Charsets.UTF_8));
         } catch (FileNotFoundException e) {
-            throw new KeyNotFoundException("Key not found: " + keyFile);
+            throw keyNotFound(keyFile.getPath());
         } catch (IOException e) {
             throw new KeyIOException("Failed to read key: " + keyFile, e);
         }

--- a/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
+++ b/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
@@ -3,9 +3,7 @@ package io.token.sample;
 import static io.token.proto.AliasHasher.normalize;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.BANK;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.EIDAS;
-import static io.token.proto.common.security.SecurityProtos.Key.Level.LOW;
 import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
-import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.eidas.EidasProtos;
@@ -144,9 +142,9 @@ public class EidasMethodsSample {
 
     /**
      * Creates a TPP member under realm of a bank and registers it with the provided eIDAS
-     * certificate. The created has a registered PRIVILEGED-level RSA key taken from the provided
+     * certificate. The created member has a registered PRIVILEGED-level RSA key from the provided
      * certificate and an EIDAS alias with value equal to authNumber from the certificate.<br><br>
-     * Note, that tokenClient needs to be create with a CryptoEngine that handles RSA keys, for
+     * Note, that tokenClient needs to be created with a CryptoEngine that handles RSA keys, for
      * example:<br><br>
      * <pre>
      * CryptoEngineFactory cryptoEngineFactory = new TokenCryptoEngineFactory(
@@ -160,7 +158,7 @@ public class EidasMethodsSample {
      * @param tokenClient token client
      * @param keyStore a key store that is used by token client (can be empty)
      * @param bankId id of the bank the TPP trying to get access to
-     * @param eidasKeyPair eIDAS key pair for the providede certificate
+     * @param eidasKeyPair eIDAS key pair for the provided certificate
      * @param certificate base64 encoded eIDAS certificate (a single line, no header and footer)
      * @return a newly created member
      */

--- a/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
+++ b/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
@@ -4,6 +4,7 @@ import static io.token.proto.AliasHasher.normalize;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.BANK;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.EIDAS;
 import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+import static io.token.util.Util.generateNonce;
 
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.eidas.EidasProtos;
@@ -155,6 +156,7 @@ public class EidasMethodsSample {
      *         .withCryptoEngine(cryptoEngineFactory)
      *         .build();
      * </pre>
+     *
      * @param tokenClient token client
      * @param keyStore a key store that is used by token client (can be empty)
      * @param bankId id of the bank the TPP trying to get access to
@@ -172,12 +174,13 @@ public class EidasMethodsSample {
         Algorithm signingAlgorithm = Algorithm.RS256;
         Crypto crypto = CryptoRegistry.getInstance().cryptoFor(signingAlgorithm);
         // key id is not important here
-        Signer payloadSigner = crypto.signer("eidas", eidasKeyPair.getPrivate());
+        Signer payloadSigner = crypto.signer(generateNonce(), eidasKeyPair.getPrivate());
 
         EidasProtos.RegisterWithEidasPayload payload = EidasProtos.RegisterWithEidasPayload
                 .newBuilder()
                 .setCertificate(certificate)
-                .setBankId(bankId).build();
+                .setBankId(bankId)
+                .build();
 
         RegisterWithEidasResponse resp = tokenClient
                 .registerWithEidas(payload, payloadSigner.sign(payload))

--- a/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
+++ b/tpp-sample/src/main/java/io/token/sample/EidasMethodsSample.java
@@ -3,17 +3,23 @@ package io.token.sample;
 import static io.token.proto.AliasHasher.normalize;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.BANK;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.EIDAS;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.LOW;
 import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
+import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 
 import io.token.proto.common.alias.AliasProtos.Alias;
+import io.token.proto.common.eidas.EidasProtos;
 import io.token.proto.common.eidas.EidasProtos.EidasRecoveryPayload;
 import io.token.proto.common.eidas.EidasProtos.VerifyEidasPayload;
 import io.token.proto.common.security.SecurityProtos;
 import io.token.proto.common.security.SecurityProtos.Key.Algorithm;
 import io.token.proto.gateway.Gateway.GetEidasVerificationStatusResponse;
+import io.token.proto.gateway.Gateway.RegisterWithEidasResponse;
 import io.token.proto.gateway.Gateway.VerifyEidasResponse;
 import io.token.security.CryptoEngine;
 import io.token.security.InMemoryKeyStore;
+import io.token.security.KeyStore;
+import io.token.security.SecretKey;
 import io.token.security.Signer;
 import io.token.security.TokenCryptoEngine;
 import io.token.security.crypto.Crypto;
@@ -21,6 +27,7 @@ import io.token.security.crypto.CryptoRegistry;
 import io.token.tpp.Member;
 import io.token.tpp.TokenClient;
 
+import java.security.KeyPair;
 import java.security.PrivateKey;
 
 public class EidasMethodsSample {
@@ -30,7 +37,7 @@ public class EidasMethodsSample {
      *
      * @param client token client
      * @param tppAuthNumber authNumber of the TPP
-     * @param certificate base64 encoded eIDAS certificate
+     * @param certificate base64 encoded eIDAS certificate (a single line, no header and footer)
      * @param bankId id of the bank the TPP trying to get access to
      * @param privateKey private key corresponding to the public key in the certificate
      * @return verified business member
@@ -83,7 +90,7 @@ public class EidasMethodsSample {
      * @param client token client
      * @param memberId id of the member to be recovered
      * @param tppAuthNumber authNumber of the TPP
-     * @param certificate base64 encoded eIDAS certificate
+     * @param certificate base64 encoded eIDAS certificate (a single line, no header and footer)
      * @param certificatePrivateKey private key corresponding to the public key in the certificate
      * @return verified business member
      */
@@ -133,5 +140,60 @@ public class EidasMethodsSample {
                 .blockingSingle();
 
         return recoveredMember;
+    }
+
+    /**
+     * Creates a TPP member under realm of a bank and registers it with the provided eIDAS
+     * certificate. The created has a registered PRIVILEGED-level RSA key taken from the provided
+     * certificate and an EIDAS alias with value equal to authNumber from the certificate.<br><br>
+     * Note, that tokenClient needs to be create with a CryptoEngine that handles RSA keys, for
+     * example:<br><br>
+     * <pre>
+     * CryptoEngineFactory cryptoEngineFactory = new TokenCryptoEngineFactory(
+     *         keyStore,
+     *         CryptoType.RS256);
+     * TokenClient tokenClient = TokenClient.builder()
+     *         .connectTo(SANDBOX)
+     *         .withCryptoEngine(cryptoEngineFactory)
+     *         .build();
+     * </pre>
+     * @param tokenClient token client
+     * @param keyStore a key store that is used by token client (can be empty)
+     * @param bankId id of the bank the TPP trying to get access to
+     * @param eidasKeyPair eIDAS key pair for the providede certificate
+     * @param certificate base64 encoded eIDAS certificate (a single line, no header and footer)
+     * @return a newly created member
+     */
+    public static Member registerWithEidas(
+            TokenClient tokenClient,
+            KeyStore keyStore,
+            String bankId,
+            KeyPair eidasKeyPair,
+            String certificate) {
+        // create a signer using the certificate private key
+        Algorithm signingAlgorithm = Algorithm.RS256;
+        Crypto crypto = CryptoRegistry.getInstance().cryptoFor(signingAlgorithm);
+        // key id is not important here
+        Signer payloadSigner = crypto.signer("eidas", eidasKeyPair.getPrivate());
+
+        EidasProtos.RegisterWithEidasPayload payload = EidasProtos.RegisterWithEidasPayload
+                .newBuilder()
+                .setCertificate(certificate)
+                .setBankId(bankId).build();
+
+        RegisterWithEidasResponse resp = tokenClient
+                .registerWithEidas(payload, payloadSigner.sign(payload))
+                .blockingSingle();
+        String memberId = resp.getMemberId();
+        // don't forget to add the registered key to the key store used by the tokenClient
+        keyStore.put(memberId, SecretKey.create(resp.getKeyId(), PRIVILEGED, eidasKeyPair));
+
+        // now we can load a member and also check a status of the certificate verification
+        Member member = tokenClient.getMemberBlocking(memberId);
+        GetEidasVerificationStatusResponse statusResp = member
+                .getEidasVerificationStatus(resp.getVerificationId())
+                .blockingSingle();
+
+        return member;
     }
 }

--- a/tpp-sample/src/test/java/io/token/sample/EidasMethodsSampleTest.java
+++ b/tpp-sample/src/test/java/io/token/sample/EidasMethodsSampleTest.java
@@ -2,36 +2,21 @@ package io.token.sample;
 
 import static com.google.common.io.BaseEncoding.base64;
 import static com.google.common.io.BaseEncoding.base64Url;
-import static io.token.TokenClient.TokenCluster.DEVELOPMENT;
 import static io.token.proto.common.alias.AliasProtos.Alias.Type.EIDAS;
 import static io.token.proto.common.eidas.EidasProtos.EidasCertificateStatus.CERTIFICATE_VALID;
-import static io.token.proto.common.security.SecurityProtos.Key.Level.LOW;
 import static io.token.proto.common.security.SecurityProtos.Key.Level.PRIVILEGED;
-import static io.token.proto.common.security.SecurityProtos.Key.Level.STANDARD;
 import static io.token.sample.EidasMethodsSample.registerWithEidas;
 import static io.token.sample.TestUtil.createClient;
 import static io.token.security.crypto.CryptoType.RS256;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.google.common.io.BaseEncoding;
 import io.token.proto.common.alias.AliasProtos.Alias;
-import io.token.proto.common.eidas.EidasProtos;
-import io.token.proto.common.security.SecurityProtos.Key;
-import io.token.proto.common.security.SecurityProtos.Key.Algorithm;
-import io.token.proto.gateway.Gateway;
+import io.token.proto.common.security.SecurityProtos;
 import io.token.proto.gateway.Gateway.GetEidasCertificateStatusResponse;
-import io.token.security.CryptoEngine;
 import io.token.security.CryptoEngineFactory;
 import io.token.security.InMemoryKeyStore;
 import io.token.security.KeyStore;
-import io.token.security.SecretKey;
-import io.token.security.Signer;
-import io.token.security.TokenCryptoEngine;
 import io.token.security.TokenCryptoEngineFactory;
-import io.token.security.crypto.Crypto;
-import io.token.security.crypto.CryptoRegistry;
-import io.token.security.crypto.CryptoType;
 import io.token.tpp.Member;
 import io.token.tpp.TokenClient;
 
@@ -123,9 +108,11 @@ public class EidasMethodsSampleTest {
             KeyPair keyPair = generateKeyPair();
             String certificate = generateCert(keyPair, authNumber);
             Member member = registerWithEidas(tokenClient, keyStore, "gold", keyPair, certificate);
+            List<SecurityProtos.Key> keys = member.getKeys().blockingSingle();
+            assertThat(keys.get(0).getLevel()).isEqualTo(PRIVILEGED);
+            assertThat(keys.get(0).getPublicKey()).isEqualTo(
+                    base64Url().encode(keyPair.getPublic().getEncoded()));
             assertThat(member.aliases().blockingSingle().get(0).getValue()).isEqualTo(authNumber);
-            assertThat(member.getKeys().blockingSingle().get(0).getPublicKey())
-                    .isEqualTo(base64Url().encode(keyPair.getPublic().getEncoded()));
         }
     }
 

--- a/tpp-sample/src/test/java/io/token/sample/TestUtil.java
+++ b/tpp-sample/src/test/java/io/token/sample/TestUtil.java
@@ -5,6 +5,8 @@ import static io.token.proto.common.alias.AliasProtos.Alias.Type.EMAIL;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.token.proto.common.alias.AliasProtos.Alias;
+import io.token.security.CryptoEngineFactory;
+import io.token.security.KeyStore;
 import io.token.tpp.TokenClient;
 import io.token.util.Util;
 
@@ -27,6 +29,10 @@ public abstract class TestUtil {
      */
     public static TokenClient createClient() {
         return TokenClient.create(DEVELOPMENT, DEV_KEY);
+    }
+
+    public static TokenClient createClient(CryptoEngineFactory cryptoEngineFactory) {
+        return TokenClient.create(DEVELOPMENT, DEV_KEY, cryptoEngineFactory);
     }
 
     /**

--- a/tpp/src/main/java/io/token/tpp/TokenClient.java
+++ b/tpp/src/main/java/io/token/tpp/TokenClient.java
@@ -47,7 +47,6 @@ import io.token.rpc.client.lite.RpcChannelFactoryLite;
 import io.token.security.CryptoEngine;
 import io.token.security.CryptoEngineFactory;
 import io.token.security.InMemoryKeyStore;
-import io.token.security.KeyStore;
 import io.token.security.TokenCryptoEngineFactory;
 import io.token.tokenrequest.TokenRequest;
 import io.token.tokenrequest.TokenRequestResult;
@@ -432,10 +431,8 @@ public class TokenClient extends io.token.TokenClient {
      * certificate. Then onboards the member with the provided certificate.
      * A successful onboarding includes verifying the member and the alias and adding permissions
      * based on the certificate.<br>
-     * The call is idempotent, so if a member under this realm and with the same verified alias
-     * already exists, it returns an ID of the existing member, an ID of the registered eidas key
-     * and an ID of the verification for this certificate.<br>
-     * If you wish to submit another certificate for an existing member, please use VerifyEidas call
+     * The call is idempotent.<br>
+     * If you need to submit another certificate for an existing member, please use VerifyEidas call
      * instead.<br><br>
      * Note, that the call is asynchronous and the newly created member might not be onboarded at
      * the time the call returns. You can check the verification status using

--- a/tpp/src/main/java/io/token/tpp/TokenClient.java
+++ b/tpp/src/main/java/io/token/tpp/TokenClient.java
@@ -37,14 +37,17 @@ import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 import io.token.proto.common.alias.AliasProtos.Alias;
 import io.token.proto.common.eidas.EidasProtos.EidasRecoveryPayload;
+import io.token.proto.common.eidas.EidasProtos.RegisterWithEidasPayload;
 import io.token.proto.common.member.MemberProtos;
 import io.token.proto.common.member.MemberProtos.MemberRecoveryOperation;
 import io.token.proto.common.security.SecurityProtos;
 import io.token.proto.common.token.TokenProtos;
+import io.token.proto.gateway.Gateway.RegisterWithEidasResponse;
 import io.token.rpc.client.lite.RpcChannelFactoryLite;
 import io.token.security.CryptoEngine;
 import io.token.security.CryptoEngineFactory;
 import io.token.security.InMemoryKeyStore;
+import io.token.security.KeyStore;
 import io.token.security.TokenCryptoEngineFactory;
 import io.token.tokenrequest.TokenRequest;
 import io.token.tokenrequest.TokenRequestResult;
@@ -104,6 +107,26 @@ public class TokenClient extends io.token.TokenClient {
         return TokenClient.builder()
                 .connectTo(cluster)
                 .devKey(developerKey)
+                .build();
+    }
+
+    /**
+     * Creates a new instance of {@link TokenClient} that's configured to use
+     * the specified environment and crypto engine factory.
+     *
+     * @param cluster token cluster to connect to
+     * @param developerKey developer key
+     * @param cryptoEngineFactory crypto engine factory to use
+     * @return {@link TokenClient} instance
+     */
+    public static TokenClient create(
+            TokenCluster cluster,
+            String developerKey,
+            CryptoEngineFactory cryptoEngineFactory) {
+        return TokenClient.builder()
+                .connectTo(cluster)
+                .devKey(developerKey)
+                .withCryptoEngine(cryptoEngineFactory)
                 .build();
     }
 
@@ -401,6 +424,33 @@ public class TokenClient extends io.token.TokenClient {
                             client,
                             tokenCluster);
                 });
+    }
+
+    /**
+     * Creates a business member under realm of a bank with an EIDAS alias (with value equal to the
+     * authNumber from the certificate) and a PRIVILEGED-level public key taken from the
+     * certificate. Then onboards the member with the provided certificate.
+     * A successful onboarding includes verifying the member and the alias and adding permissions
+     * based on the certificate.<br>
+     * The call is idempotent, so if a member under this realm and with the same verified alias
+     * already exists, it returns an ID of the existing member, an ID of the registered eidas key
+     * and an ID of the verification for this certificate.<br>
+     * If you wish to submit another certificate for an existing member, please use VerifyEidas call
+     * instead.<br><br>
+     * Note, that the call is asynchronous and the newly created member might not be onboarded at
+     * the time the call returns. You can check the verification status using
+     * member.getEidasVerificationStatus call with the verification id returned by this call.
+     *
+     * @param payload payload with eIDAS certificate and bank id
+     * @param signature payload signed with the private key corresponding to the certificate
+     *      public key
+     * @return member id, registered key id and id of the certificate verification request
+     */
+    public Observable<RegisterWithEidasResponse> registerWithEidas(
+            RegisterWithEidasPayload payload,
+            String signature) {
+        UnauthenticatedClient unauthenticated = ClientFactory.unauthenticated(channel);
+        return unauthenticated.registerWithEidas(payload, signature);
     }
 
     /**


### PR DESCRIPTION
To make it work, I also had to 
1) add possibility to create keys for different crypto types in TokenCryptoEngine;
2) use a key of a requested level or higher (if no key can be found for the requested level) in ClientAuthenticator;

I also formalized exceptions thrown by KeyStore when a key cannot be found or expired, to better catch exception it ClientAuthenticator when looking for an existing key.