### PR TITLE
bump rpc-lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ allprojects {
     }
 
     group = 'io.token.sdk'
-    version = '2.9.6'
+    version = '2.9.7'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     ext {
         ver = [
             tokenProto           : '1.10.36',
-            tokenRpc             : '2.0.0',
+            tokenRpc             : '2.0.4',
             tokenSecurity        : '1.1.14',
             rxjava               : '2.1.1',
         ]


### PR DESCRIPTION
rpc logger to consider usage of new extension `hash` for fields in proto objects.