### PR TITLE
PLT-795: resolve dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,12 +80,15 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    api(project(':user')){
-        exclude group: "com.google.api.grpc", module:"proto-google-common-protos"
-        exclude group: "io.token.rpc", module:"tokenio-rpc-client-lite-netty"
+    compile(project(':user')){
+        exclude group: 'com.google.api.grpc', module: 'proto-google-common-protos'
+        exclude group: 'io.token.rpc', module: 'tokenio-rpc-client-lite-netty'
+        exclude group: 'org.checkerframework' //, module: 'checker'
     }
-    api(group: 'io.token.rpc', name: 'tokenio-rpc-client-lite-okhttp', version: ver.tokenRpc){
-        exclude group: "com.google.api.grpc", module:"proto-google-common-protos"
+    compile(group: 'io.token.rpc', name: 'tokenio-rpc-client-lite-okhttp', version: ver.tokenRpc){
+        exclude group: 'com.google.api.grpc', module:'proto-google-common-protos'
+        exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'org.checkerframework' //, module: 'checker'
     }
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
@@ -143,3 +146,16 @@ signing {
 }
 
 apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'
+
+tasks.withType(Javadoc) {
+    failOnError false
+}
+
+configurations.all { configuration ->
+    // Ignore ':lintClassPath' configuration as it has version conflicts.
+    if (!"$configuration".contains(':lintClassPath')) {
+        resolutionStrategy {
+            failOnVersionConflict()
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,11 @@ buildscript {
         mavenLocal()
         jcenter()
         maven { url 'https://token.jfrog.io/token/public-gradle-plugins-local/' }
+        maven { url 'https://token.jfrog.io/token/plugins-release/' }
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'io.token.gradle:token-gradle:1.1.12'
+        classpath 'io.token.gradle:token-gradle:1.3.2'
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.21'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
@@ -23,13 +24,13 @@ buildscript {
 allprojects {
     ext {
         ver = [
-            tokenProto           : '1.11.31',
-            tokenRpc             : '2.0.4',
-            tokenSecurity        : '1.4.1',
+            tokenProto           : '1.11.36',
+            tokenRpc             : '2.1.4',
+            tokenSecurity        : '1.4.2',
             rxjava               : '2.1.1',
         ]
     }
 
     group = 'io.token.sdk'
-    version = '2.12.5'
+    version = '2.12.6'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,11 +10,17 @@ publish {
 }
 
 dependencies {
-    compile group: 'io.token.proto', name: 'tokenio-proto-external', version: ver.tokenProto
-    compile group: 'io.token.rpc', name: 'tokenio-rpc-client-api', version: ver.tokenRpc
-    compile group: 'io.token.rpc', name: 'tokenio-rpc-client-lite', version: ver.tokenRpc
-    compile group: 'io.token.rpc', name: 'tokenio-rpc-client-lite-netty', version: ver.tokenRpc
-    compile group: 'io.token.security', name: 'tokenio-security-lib', version: ver.tokenSecurity
+    ext.compileExcludeGuava = { dependency ->
+        compile (dependency) {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+    }
+
+    compileExcludeGuava("io.token.proto:tokenio-proto-external:${ver.tokenProto}")
+    compileExcludeGuava("io.token.rpc:tokenio-rpc-client-api:${ver.tokenRpc}")
+    compileExcludeGuava("io.token.rpc:tokenio-rpc-client-lite:${ver.tokenRpc}")
+    compileExcludeGuava("io.token.rpc:tokenio-rpc-client-lite-netty:${ver.tokenRpc}")
+    compileExcludeGuava("io.token.security:tokenio-security-lib:${ver.tokenSecurity}")
     compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: ver.rxjava
 }
 
@@ -36,4 +42,10 @@ license {
 downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = 'compile'
+}
+
+configurations.compileClasspath {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
 }

--- a/tpp/build.gradle
+++ b/tpp/build.gradle
@@ -12,10 +12,6 @@ publish {
 
 dependencies {
     compile project(':core')
-    compile group: 'io.token.proto', name: 'tokenio-proto-external', version: ver.tokenProto
-    compile group: 'io.token.rpc', name: 'tokenio-rpc-client-lite', version: ver.tokenRpc
-    compile group: 'io.token.security', name: 'tokenio-security-lib', version: ver.tokenSecurity
-    compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: ver.rxjava
 }
 
 license {
@@ -36,4 +32,10 @@ license {
 downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = 'compile'
+}
+
+configurations.compileClasspath {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
 }

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -12,10 +12,6 @@ publish {
 
 dependencies {
     compile project(':core')
-    compile group: 'io.token.proto', name: 'tokenio-proto-external', version: ver.tokenProto
-    compile group: 'io.token.rpc', name: 'tokenio-rpc-client-lite', version: ver.tokenRpc
-    compile group: 'io.token.security', name: 'tokenio-security-lib', version: ver.tokenSecurity
-    compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: ver.rxjava
 }
 
 license {
@@ -36,4 +32,10 @@ license {
 downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = 'compile'
+}
+
+configurations.compileClasspath {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
 }


### PR DESCRIPTION
1. Android java doc is not in plan. Should not block the build if broken.
2. add failOnVersionConflict to check all sdks don't have transitive conflicts. (For non-gradle users.)
3. bump versions.